### PR TITLE
fix: switch account no longer redirects to login page

### DIFF
--- a/frontend/src/components/user-profile-menu.ts
+++ b/frontend/src/components/user-profile-menu.ts
@@ -186,7 +186,10 @@ export class UserProfileMenu extends LitElement {
          if (overlayDiv) overlayDiv.style.opacity = '0';
          setTimeout(() => overlayContainer.remove(), 300);
       } else {
-         clearSessionSettings();
+         // Keep the auth detection cookies: the switch response already installed a
+         // valid session for the new account. Clearing them would make the reloaded
+         // SPA think it is logged out and redirect to the login page.
+         clearSessionSettings(false);
          sessionStorage.clear();
          window.location.reload();
       }

--- a/frontend/src/store/settings-store.ts
+++ b/frontend/src/store/settings-store.ts
@@ -421,7 +421,13 @@ export class SettingsStore extends EventTarget {
 
 export const settingsContext = createContext<SettingsStore>('settings-store');
 
-export function clearSessionSettings() {
+// clearSessionSettings resets cached per-account settings to defaults (preserving
+// cross-account UI preferences). By default it also clears the client-side auth
+// detection cookies, which is what logout / session-expiry callers want. Account
+// switching must pass clearAuthCookies=false: the switch response already installed
+// a valid session for the new account, and deleting alps_logged_in / alps_has_login_token
+// here would make the reloaded SPA believe it is logged out and bounce to #/login.
+export function clearSessionSettings(clearAuthCookies: boolean = true) {
   const stored = localStorage.getItem('alps_settings');
   if (stored) {
     try {
@@ -441,6 +447,10 @@ export function clearSessionSettings() {
       Logger.error('Failed to clear and preserve global settings', e);
       localStorage.removeItem('alps_settings');
     }
+  }
+
+  if (!clearAuthCookies) {
+    return;
   }
 
   // Clear client-side authentication cookies to avoid loop requests on session expiry/restart


### PR DESCRIPTION
## Problem

Using the **Switch account** feature bounces the user back to the login page, even though the account switch actually succeeds on the backend.

## Root cause

This is a false, frontend-only logout.

1. `POST /accounts/switch` succeeds and installs a valid session for the target account: `alps_session` (HttpOnly) plus the JS-visible detection cookies `alps_logged_in=1` / `alps_has_login_token=1`.
2. The frontend switch handler then runs `clearSessionSettings()` before `window.location.reload()`.
3. `clearSessionSettings()` **deletes** `alps_logged_in` and `alps_has_login_token` — the exact two cookies the SPA uses to decide "am I logged in?".
4. On reload the authenticated GET happy-path never re-sets those cookies, so `app-root` / `settings-store` read *not logged in* and redirect to `#/login`.

The real session (`alps_session`, HttpOnly, untouched) was valid the whole time.

`clearSessionSettings()` is correct for its other callers (auth-error, header logout, auto-logout — all genuine logouts). Account switching is the only caller that must stay logged in. Per-account settings are keyed as `alps_settings_${username}`, so the new account already loads its own settings on reload — wiping cookies bought nothing here.

## Fix

- Add a `clearAuthCookies` parameter to `clearSessionSettings` (default `true`, preserving existing logout behavior).
- The account-switch path now calls `clearSessionSettings(false)`, keeping the detection cookies intact across the reload.

## Verification

- `tsc && vite build` pass.
- Drove the **real** `clearSessionSettings` in headless Chrome (via CDP, served through Vite) and observed the cookie gate that drives the redirect:
  - Switch path (`clearSessionSettings(false)`): `alps_logged_in` / `alps_has_login_token` survive → login gate stays *logged in*, no redirect. ✅
  - Logout path (default): still clears both cookies → gate becomes *logged out* (regression guard; this is exactly the old buggy switch behavior). ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)