### PR TITLE
fix: show forwarded-as-attachment messages and stop oversized HTML rendering

### DIFF
--- a/frontend/src/components/alps-thread-card.ts
+++ b/frontend/src/components/alps-thread-card.ts
@@ -469,7 +469,7 @@ export class AlpsThreadCard extends LitElement {
               .srcdoc=${live(this.item.content)}
               @load=${this.onIframeLoad}
             ></iframe>
-          ` : this.item.mimeType?.toLowerCase().startsWith('multipart/') ? html`
+          ` : this.item.mimeType?.toLowerCase().startsWith('multipart/') || !this.item.content ? html`
             <div class="reader-empty-body">
               ${this.i18nStore?.t('messageReader.noReadableText')}
             </div>

--- a/frontend/src/components/message-reader.ts
+++ b/frontend/src/components/message-reader.ts
@@ -1726,7 +1726,7 @@ export class MessageReader extends LitElement {
                 .srcdoc=${live(this.content)}
                 @load=${this.onIframeLoad}
               ></iframe>
-            ` : this.mimeType?.toLowerCase().startsWith('multipart/') ? html`
+            ` : this.mimeType?.toLowerCase().startsWith('multipart/') || !this.content ? html`
               <div class="reader-empty-body">
                 ${this.i18nStore?.t('messageReader.noReadableText')}
               </div>

--- a/frontend/src/utils/html-sanitizer.ts
+++ b/frontend/src/utils/html-sanitizer.ts
@@ -156,7 +156,7 @@ export function sanitizeMessageHTML(rawHtml: string, options: SanitizeOptions): 
 
   const style = doc.createElement('style');
   style.textContent = `
-    body { margin: 0; padding: 24px; box-sizing: border-box; font: 14px -apple-system, system-ui, 'Segoe UI', Roboto, sans-serif; overflow-x: hidden; word-wrap: break-word; background-color: #ffffff; color: #000000; }
+    body { margin: 0; padding: 24px; box-sizing: border-box; font: 14px -apple-system, system-ui, 'Segoe UI', Roboto, sans-serif; overflow-x: auto; word-wrap: break-word; background-color: #ffffff; color: #000000; }
     @media (max-width: 768px) { body { padding: 16px !important; } }
     html:not(.x), body:not(.x) { height: auto !important; }
     p:first-child { margin-top: 0; }

--- a/frontend/src/utils/reader-utils.ts
+++ b/frontend/src/utils/reader-utils.ts
@@ -69,21 +69,22 @@ export function setupIframeSizing(iframe: HTMLIFrameElement, themeIframeContent:
     (iframe as any)._ro.disconnect();
   }
 
-  let parentWidth = 0;
+  // The iframe stays locked to its container's width (100%). We only sync its
+  // height to the content so the whole page scrolls as one. We deliberately do
+  // NOT grow the iframe to the content's width: emails with fixed-width layouts
+  // or wide tables would otherwise blow the iframe out past the viewport,
+  // producing an enormous, broken-looking message. Content wider than the pane
+  // scrolls horizontally inside the iframe instead (see html-sanitizer body
+  // overflow-x).
   const ro = new ResizeObserver((entries) => {
     let newHeight = 0;
-    let newWidth = 0;
 
     for (const entry of entries) {
-      if (entry.target === iframe.parentElement) {
-        parentWidth = entry.contentRect.width;
-      } else if (iframe.contentDocument && entry.target === iframe.contentDocument.body) {
+      if (iframe.contentDocument && entry.target === iframe.contentDocument.body) {
         if (entry.borderBoxSize && entry.borderBoxSize.length > 0) {
           newHeight = entry.borderBoxSize[0].blockSize;
-          newWidth = entry.borderBoxSize[0].inlineSize;
         } else {
           newHeight = entry.contentRect.height + 48;
-          newWidth = entry.contentRect.width + 48;
         }
       }
     }
@@ -94,19 +95,9 @@ export function setupIframeSizing(iframe: HTMLIFrameElement, themeIframeContent:
         iframe.style.height = `${Math.ceil(newHeight)}px`;
       }
     }
-
-    if (parentWidth > 0 && newWidth > parentWidth) {
-      const currentWidth = parseFloat(iframe.style.width) || 0;
-      if (Math.abs(currentWidth - newWidth) > 2) {
-        iframe.style.width = `${Math.ceil(newWidth)}px`;
-      }
-    }
   });
 
   ro.observe(iframe.contentDocument.body);
-  if (iframe.parentElement) {
-    ro.observe(iframe.parentElement);
-  }
   (iframe as any)._ro = ro;
 }
 

--- a/plugins/base/attachments_test.go
+++ b/plugins/base/attachments_test.go
@@ -1,0 +1,88 @@
+package alpsbase
+
+import (
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapclient"
+)
+
+// newTestMessage wraps a body structure in an IMAPMessage for exercising the
+// TextPart/HTMLPart/Attachments helpers.
+func newTestMessage(bs imap.BodyStructure) *IMAPMessage {
+	return &IMAPMessage{
+		FetchMessageBuffer: &imapclient.FetchMessageBuffer{BodyStructure: bs},
+	}
+}
+
+func inlineDisposition() *imap.BodyStructureSinglePartExt {
+	return &imap.BodyStructureSinglePartExt{
+		Disposition: &imap.BodyStructureDisposition{Value: "inline"},
+	}
+}
+
+// A message forwarded "as an attachment" whose message/rfc822 part is marked
+// inline, carries no Content-ID and no filename — the exact shape that used to
+// be dropped from Attachments(), leaving the reader completely blank.
+func TestAttachmentsIncludesInlineMessageRFC822(t *testing.T) {
+	msg := newTestMessage(&imap.BodyStructureMultiPart{
+		Subtype: "mixed",
+		Children: []imap.BodyStructure{
+			// The (empty) forwarding note.
+			&imap.BodyStructureSinglePart{Type: "text", Subtype: "plain"},
+			// The forwarded message, marked inline with no filename / no ID.
+			&imap.BodyStructureSinglePart{
+				Type:    "message",
+				Subtype: "rfc822",
+				MessageRFC822: &imap.BodyStructureMessageRFC822{
+					Envelope: &imap.Envelope{Subject: "Quarterly report"},
+				},
+				Extended: inlineDisposition(),
+			},
+		},
+	})
+
+	atts := msg.Attachments()
+	if len(atts) != 1 {
+		t.Fatalf("expected the forwarded message to be listed as 1 attachment, got %d", len(atts))
+	}
+	if atts[0].MIMEType != "message/rfc822" {
+		t.Errorf("expected message/rfc822 attachment, got %q", atts[0].MIMEType)
+	}
+	// The forwarded message has no filename, so the subject is used as a
+	// friendly fallback name.
+	if atts[0].Filename != "Quarterly report.eml" {
+		t.Errorf("expected filename derived from subject, got %q", atts[0].Filename)
+	}
+
+	// It must not be mistaken for a renderable text/HTML body.
+	if tp := msg.TextPart(); tp == nil {
+		t.Error("expected the text/plain note to still be the text part")
+	}
+}
+
+// An explicit filename on the forwarded part must win over the subject fallback.
+func TestAttachmentsMessageRFC822KeepsExplicitFilename(t *testing.T) {
+	msg := newTestMessage(&imap.BodyStructureMultiPart{
+		Subtype: "mixed",
+		Children: []imap.BodyStructure{
+			&imap.BodyStructureSinglePart{
+				Type:    "message",
+				Subtype: "rfc822",
+				Params:  map[string]string{"name": "forwarded.eml"},
+				MessageRFC822: &imap.BodyStructureMessageRFC822{
+					Envelope: &imap.Envelope{Subject: "ignored subject"},
+				},
+				Extended: inlineDisposition(),
+			},
+		},
+	})
+
+	atts := msg.Attachments()
+	if len(atts) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(atts))
+	}
+	if atts[0].Filename != "forwarded.eml" {
+		t.Errorf("expected explicit filename to be kept, got %q", atts[0].Filename)
+	}
+}

--- a/plugins/base/types.go
+++ b/plugins/base/types.go
@@ -165,6 +165,17 @@ func (msg *IMAPMessage) Attachments() []IMAPPartNode {
 			return true
 		}
 
+		// message/rfc822 (and other message/* parts) are embedded/forwarded
+		// messages. They can never be rendered as an inline body — TextPart and
+		// HTMLPart only match text/* parts, and the body-structure walk does not
+		// descend into them — so always surface them as attachments, even when a
+		// client marks them "inline" or omits both a filename and a Content-ID
+		// (common when forwarding a message as an attachment).
+		if strings.EqualFold(singlePart.Type, "message") {
+			attachments = append(attachments, *newIMAPPartNode(msg, path, singlePart))
+			return true
+		}
+
 		// Skip parts that are the primary text or HTML body
 		if textPart != nil && pathsEqual(path, textPart.Path) {
 			return true
@@ -283,6 +294,26 @@ func newIMAPPartNode(msg *IMAPMessage, path []int, part imap.BodyStructure) *IMA
 	}
 	if singlePart, ok := part.(*imap.BodyStructureSinglePart); ok {
 		node.Filename = singlePart.Filename()
+		// Forwarded messages (message/rfc822) frequently carry no filename. Fall
+		// back to the embedded message's subject so the attachment shows a
+		// meaningful name instead of an "unknown attachment" placeholder.
+		if node.Filename == "" && singlePart.MessageRFC822 != nil && singlePart.MessageRFC822.Envelope != nil {
+			if subject := strings.TrimSpace(singlePart.MessageRFC822.Envelope.Subject); subject != "" {
+				clean := strings.Map(func(r rune) rune {
+					if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' || r == '.' || r == ' ' {
+						return r
+					}
+					return '_'
+				}, subject)
+				clean = strings.TrimSpace(clean)
+				if len(clean) > 100 {
+					clean = clean[:100]
+				}
+				if clean != "" {
+					node.Filename = clean + ".eml"
+				}
+			}
+		}
 		node.Params = singlePart.Params
 		node.Size = singlePart.Size
 		if strings.EqualFold(singlePart.Encoding, "base64") {


### PR DESCRIPTION
## Summary

Fixes two message-reader bugs reported against the new webmail.

### 1. A message forwarded *as an attachment* displayed nothing
The forwarded `message/rfc822` part is frequently marked `Content-Disposition: inline` with no filename and no Content-ID (Apple Mail, etc.). `Attachments()` dropped exactly that shape via the `mimeType != "text" && !inline` guard, so the attachment pill never rendered — and since there's no text body part in that case either, the reader showed a completely blank pane. The old webmail listed the attachment; the new one didn't.

- `message/*` parts can never be rendered as an inline body (`TextPart`/`HTMLPart` only match `text/*`, and the body-structure walk does not descend into them), so they're now always surfaced as attachments regardless of disposition.
- When such a part has no filename, a friendly name is derived from the embedded message's subject (`"<subject>.eml"`, sanitized) instead of showing "unknown attachment".
- The reader now shows the existing "no readable text" placeholder (instead of an empty `<pre>`) when a message has no text body — so a forwarded-as-attachment message reads clearly: placeholder + the attachment above it.

### 2. An HTML message rendered enormous ("Show HTML")
The iframe auto-sizer set the iframe's **own width to the full content width** whenever content exceeded the pane, blowing the message out far past the viewport (the outer container then scrolled the whole oversized thing).

- The iframe now stays locked to its container width (`100%`); only height is synced to content.
- Content wider than the pane scrolls horizontally *inside* the iframe instead of being clipped (injected body style `overflow-x: hidden` → `auto`).

## Tests
Adds `plugins/base/attachments_test.go` covering:
- an inline `message/rfc822` (no filename, no Content-ID) is now surfaced as an attachment, and
- the subject-derived filename fallback, with an explicit filename still taking precedence.

`go build ./...`, `go test ./plugins/base/`, and `tsc --noEmit` all pass.

## Note
`frontend/dist/` is committed in this repo and there is no CI build step. This PR contains **source changes only** — the frontend bundle needs to be rebuilt (`cd frontend && npm run build`) and committed for the fix to take effect in the served app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)