### PR TITLE
fix(compose): preserve plaintext edits when toggling off rich text (#6)

### DIFF
--- a/frontend/src/components/alps-message-composer.ts
+++ b/frontend/src/components/alps-message-composer.ts
@@ -275,7 +275,11 @@ export class AlpsMessageComposer extends LitElement {
 
   updated(changedProperties: PropertyValues) {
     if (changedProperties.has('isSending') && this.editor) {
-      this.editor.setEditable(!this.isSending);
+      // Pass emitUpdate=false: TipTap v3's setEditable emits an "update" event by
+      // default, which fires onUpdate. In plaintext mode that would overwrite the
+      // user's text with the editor's stale, HTML-derived content right before the
+      // message is assembled for sending. See GitHub issue #6.
+      this.editor.setEditable(!this.isSending, false);
     }
     if (changedProperties.has('format')) {
       const oldFormat = changedProperties.get('format');
@@ -321,6 +325,12 @@ export class AlpsMessageComposer extends LitElement {
       ],
       content: this.htmlText || (this.format === 'html' ? this.text.split('\n').map(line => `<p>${line}</p>`).join('') : this.text),
       onUpdate: ({ editor }) => {
+        // The TipTap editor is only the source of truth in HTML mode. In plaintext
+        // mode the <textarea> owns the content, so ignore editor updates there;
+        // otherwise a programmatic editor update (e.g. setEditable(false) on send)
+        // would clobber the user's plaintext with stale, HTML-derived text.
+        // See GitHub issue #6.
+        if (this.format !== 'html') return;
         this.htmlText = editor.getHTML();
         this.text = editor.getText();
         this.dispatchEvent(new CustomEvent('text-changed', {


### PR DESCRIPTION
## Problem (fixes #6)

With compose set to **Rich Text (HTML)**, if you switch to plaintext using the "Aa" formatting toggle, edit the body, and send, the **stale original HTML content is sent** instead of your edited plaintext. The message is correctly sent as `text/plain`, but with the wrong content.

### Steps to reproduce
1. Settings → compose format = Rich Text (HTML)
2. Compose a new message, type `this is html` in the body
3. Click the "Aa" toggle (switch to plaintext)
4. Change the body to `this is plain`
5. Send → the received message wrongly contains `this is html`

## Root cause

On send, `isSending = true` triggers `this.editor.setEditable(false)` in `alps-message-composer.ts`. In TipTap v3, `setEditable(editable, emitUpdate = true)` **emits an `"update"` event by default**, firing the editor's `onUpdate`. That handler does `this.text = editor.getText()` (the stale HTML-derived text) and dispatches `text-changed`, overwriting the composer's text buffer right before the outgoing body is assembled.

It only bites after an HTML→plaintext toggle because in pure HTML mode the editor legitimately owns the content, so re-reading it is harmless; after the toggle the `<textarea>` becomes the source of truth but the hidden editor silently reclaims the shared buffer.

## Fix

- Pass `emitUpdate = false` to `setEditable`, so toggling editability no longer emits a spurious update.
- Guard `onUpdate` to only sync from the editor while `format === 'html'` (defense-in-depth: the hidden editor must never clobber the plaintext buffer).

Confirmed against the installed TipTap source (`@tiptap/core` `setEditable` at `dist/index.js`). Frontend typechecks and builds.

> Note: the built `frontend/dist` bundle is not included in this PR; run `make build-frontend` before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)