### PR TITLE
fix(csrf): support TLS-terminating reverse proxies (X-Forwarded-Proto/Host, trusted_origins) (#5)

### DIFF
--- a/cmd/alps/config.go
+++ b/cmd/alps/config.go
@@ -77,7 +77,8 @@ type ServerConfig struct {
 	Debug                   bool            `toml:"debug"`
 	LoginKey                string          `toml:"login_key"`
 	TempDir                 string          `toml:"temp_dir"`
-	TrustedProxies          []string        `toml:"trusted_proxies"`            // Trust X-Forwarded-For headers from these proxy IPs/CIDRs
+	TrustedProxies          []string        `toml:"trusted_proxies"`            // Trust X-Forwarded-For/Proto/Host headers from these proxy IPs/CIDRs
+	TrustedOrigins          []string        `toml:"trusted_origins"`            // Extra origins accepted by the CSRF check, e.g. "https://webmail.example.com" (for TLS-terminating reverse proxies)
 	SessionMinutes          int             `toml:"session_minutes"`            // Session timeout in minutes (default: 30)
 	MaxSessionMinutes       int             `toml:"max_session_minutes"`        // Maximum session duration users can set (0 = no limit)
 	MaxSessions             int             `toml:"max_sessions"`               // Maximum total concurrent sessions (0 = unlimited, default: 10000)
@@ -273,6 +274,20 @@ func (c *Config) ToOptions() (alps.Options, error) {
 	rlConfig.TrustedProxies = trustedProxies
 
 	options.RateLimitConfig = &rlConfig
+
+	// Trusted proxies are also used by the CSRF middleware to decide whether to
+	// honor X-Forwarded-Proto / X-Forwarded-Host when computing the expected origin.
+	options.TrustedProxies = trustedProxies
+
+	// Normalize the explicit CSRF trusted origins allowlist (lowercase, no trailing slash).
+	for _, origin := range c.Server.TrustedOrigins {
+		origin = strings.TrimSpace(origin)
+		if origin == "" {
+			continue
+		}
+		origin = strings.TrimRight(strings.ToLower(origin), "/")
+		options.TrustedOrigins = append(options.TrustedOrigins, origin)
+	}
 
 	// Set cache config (default to enabled with 10 minute TTL)
 	options.CacheEnabled = true

--- a/config.example.toml
+++ b/config.example.toml
@@ -7,10 +7,20 @@ addr = ":1323"
 # Enable debug logging
 debug = true
 
-# Trust X-Forwarded-For and X-Real-IP headers from specific proxy IPs or CIDR blocks
+# Trust X-Forwarded-For, X-Real-IP, X-Forwarded-Proto and X-Forwarded-Host headers
+# from specific proxy IPs or CIDR blocks.
 # ONLY enable this if ALPS is deployed behind a trusted reverse proxy (like Nginx or HAProxy)
 # If enabled with untrusted IPs, attackers can spoof their IP address to bypass rate limits.
+# When the immediate peer is listed here, ALPS also uses X-Forwarded-Proto/X-Forwarded-Host
+# to compute the expected Origin for the CSRF check. This is the recommended way to run ALPS
+# behind a TLS-terminating reverse proxy (proxy speaks HTTPS to the browser, HTTP to ALPS).
 # trusted_proxies = ["127.0.0.1/32", "::1/128", "10.0.0.0/8"]
+
+# Additional origins accepted by the CSRF check, in addition to the one ALPS computes
+# from the request (or from the forwarded headers above). Use this when your proxy does
+# not (or cannot) set X-Forwarded-Proto/Host, or as an explicit override. The browser's
+# Origin header must match one of these exactly (scheme + host [+ port]).
+# trusted_origins = ["https://webmail.example.com"]
 
 # Fernet key for login persistence (optional)
 # Encrypts user credentials in browser cookies to enable "remember me" functionality

--- a/middleware.go
+++ b/middleware.go
@@ -1,6 +1,7 @@
 package alps
 
 import (
+	"net"
 	"net/http"
 	"strings"
 )
@@ -25,17 +26,37 @@ func CSRFMiddleware(next HandlerFunc) HandlerFunc {
 			return next(ctx)
 		}
 
-		// Get expected origin from request host
+		// Get expected origin from the request. When alps runs behind a trusted
+		// TLS-terminating reverse proxy, the proxy forwards over plain HTTP, so the
+		// scheme/host as seen by alps do not match what the browser sees. Honor the
+		// standard X-Forwarded-Proto / X-Forwarded-Host headers, but only when the
+		// immediate peer is a configured trusted proxy (otherwise they are spoofable).
 		scheme := "https"
 		if !ctx.IsTLS() {
 			scheme = "http"
 		}
-		expectedOrigin := scheme + "://" + ctx.Request.Host
+		host := ctx.Request.Host
+		if isRequestFromTrustedProxy(ctx) {
+			if proto := firstForwardedValue(ctx.Request.Header.Get("X-Forwarded-Proto")); proto != "" {
+				scheme = proto
+			}
+			if fwdHost := firstForwardedValue(ctx.Request.Header.Get("X-Forwarded-Host")); fwdHost != "" {
+				host = fwdHost
+			}
+		}
+		expectedOrigin := scheme + "://" + host
+
+		// Additional origins explicitly trusted via config (trusted_origins). Useful
+		// when the deployment cannot set forwarded headers or lists trusted proxies.
+		var trustedOrigins []string
+		if ctx.Server.Options != nil {
+			trustedOrigins = ctx.Server.Options.TrustedOrigins
+		}
 
 		// Check Origin header first (preferred, sent by modern browsers for POST/PUT/DELETE)
 		origin := ctx.Request.Header.Get("Origin")
 		if origin != "" {
-			if !originMatches(origin, expectedOrigin) {
+			if !originMatches(origin, expectedOrigin) && !originInList(origin, trustedOrigins) {
 				// Allow localhost origins in development (common with Vite dev server proxy)
 				if isLocalhostOrigin(origin) && isLocalhostOrigin(expectedOrigin) {
 					ctx.Server.Logger().Printf("CSRF: Allowing localhost origin mismatch in development: got %q, expected %q", origin, expectedOrigin)
@@ -50,7 +71,7 @@ func CSRFMiddleware(next HandlerFunc) HandlerFunc {
 		// Fallback to Referer header (older browsers, or when Origin is stripped)
 		referer := ctx.Request.Header.Get("Referer")
 		if referer != "" {
-			if !refererMatches(referer, expectedOrigin) {
+			if !refererMatches(referer, expectedOrigin) && !refererInList(referer, trustedOrigins) {
 				ctx.Server.Logger().Printf("CSRF: Referer mismatch: got %q, expected %q", referer, expectedOrigin)
 				return NewHTTPError(http.StatusForbidden, "Invalid referer")
 			}
@@ -87,6 +108,71 @@ func refererMatches(referer, expectedOrigin string) bool {
 	// Referer includes the full URL, so we just check if it starts with the expected origin
 	return strings.HasPrefix(strings.ToLower(referer), strings.ToLower(expectedOrigin)+"/") ||
 		strings.EqualFold(referer, expectedOrigin)
+}
+
+// originInList reports whether origin is present in the configured trusted-origins
+// allowlist. The allowlist is already normalized to lowercase without a trailing slash.
+func originInList(origin string, trustedOrigins []string) bool {
+	if len(trustedOrigins) == 0 {
+		return false
+	}
+	normalized := strings.TrimRight(strings.ToLower(origin), "/")
+	for _, trusted := range trustedOrigins {
+		if normalized == trusted {
+			return true
+		}
+	}
+	return false
+}
+
+// refererInList reports whether the referer originates from one of the configured
+// trusted origins.
+func refererInList(referer string, trustedOrigins []string) bool {
+	if len(trustedOrigins) == 0 {
+		return false
+	}
+	lower := strings.ToLower(referer)
+	for _, trusted := range trustedOrigins {
+		if lower == trusted || strings.HasPrefix(lower, trusted+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// firstForwardedValue returns the first value of a possibly comma-separated
+// forwarded header (e.g. "X-Forwarded-Proto: https, http"), trimmed of whitespace.
+func firstForwardedValue(header string) string {
+	if header == "" {
+		return ""
+	}
+	if i := strings.IndexByte(header, ','); i >= 0 {
+		header = header[:i]
+	}
+	return strings.TrimSpace(header)
+}
+
+// isRequestFromTrustedProxy reports whether the immediate peer (TCP RemoteAddr)
+// is one of the configured trusted proxies. Only then may forwarded headers be
+// trusted, since any client can otherwise set them.
+func isRequestFromTrustedProxy(ctx *Context) bool {
+	if ctx.Server == nil || ctx.Server.Options == nil || len(ctx.Server.Options.TrustedProxies) == 0 {
+		return false
+	}
+	remoteIPStr, _, err := net.SplitHostPort(ctx.Request.RemoteAddr)
+	if err != nil {
+		remoteIPStr = ctx.Request.RemoteAddr
+	}
+	remoteIP := net.ParseIP(remoteIPStr)
+	if remoteIP == nil {
+		return false
+	}
+	for _, cidr := range ctx.Server.Options.TrustedProxies {
+		if cidr.Contains(remoteIP) {
+			return true
+		}
+	}
+	return false
 }
 
 // Router wraps http.ServeMux and provides middleware support.

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -2,6 +2,7 @@ package alps
 
 import (
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -194,4 +195,153 @@ func TestWrapHandlerPanicAndError(t *testing.T) {
 	router.ServeHTTP(w2, req2)
 	assert.Equal(t, http.StatusInternalServerError, w2.Code)
 	assert.Contains(t, w2.Body.String(), "An internal error occurred")
+}
+
+func mustCIDR(s string) *net.IPNet {
+	_, n, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
+
+// TestCSRFMiddlewareBehindProxy covers running alps behind a TLS-terminating
+// reverse proxy (issue #5): forwarded headers are honored only from trusted
+// proxies, and an explicit trusted_origins allowlist is also accepted.
+func TestCSRFMiddlewareBehindProxy(t *testing.T) {
+	nextHandler := func(ctx *Context) error {
+		return ctx.String(http.StatusOK, "ok")
+	}
+	handler := CSRFMiddleware(nextHandler)
+
+	tests := []struct {
+		name           string
+		remoteAddr     string
+		trustedProxies []*net.IPNet
+		trustedOrigins []string
+		xfProto        string
+		xfHost         string
+		origin         string
+		referer        string
+		expectedStatus int
+	}{
+		{
+			name:           "trusted proxy X-Forwarded-Proto https accepts https origin",
+			remoteAddr:     "10.0.0.1:5000",
+			trustedProxies: []*net.IPNet{mustCIDR("10.0.0.0/8")},
+			xfProto:        "https",
+			origin:         "https://example.com",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "X-Forwarded-Proto ignored when peer not trusted",
+			remoteAddr:     "203.0.113.7:5000",
+			trustedProxies: []*net.IPNet{mustCIDR("10.0.0.0/8")},
+			xfProto:        "https",
+			origin:         "https://example.com",
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:           "X-Forwarded-Proto ignored when no trusted proxies configured",
+			remoteAddr:     "10.0.0.1:5000",
+			xfProto:        "https",
+			origin:         "https://example.com",
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:           "trusted proxy honors X-Forwarded-Host",
+			remoteAddr:     "10.0.0.1:5000",
+			trustedProxies: []*net.IPNet{mustCIDR("10.0.0.0/8")},
+			xfProto:        "https",
+			xfHost:         "webmail.example.com",
+			origin:         "https://webmail.example.com",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "trusted proxy honors comma-separated X-Forwarded-Proto",
+			remoteAddr:     "10.0.0.1:5000",
+			trustedProxies: []*net.IPNet{mustCIDR("10.0.0.0/8")},
+			xfProto:        "https, http",
+			origin:         "https://example.com",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "trusted_origins allowlist accepts origin",
+			remoteAddr:     "203.0.113.7:5000",
+			trustedOrigins: []string{"https://example.com"},
+			origin:         "https://example.com",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "trusted_origins allowlist accepts referer",
+			remoteAddr:     "203.0.113.7:5000",
+			trustedOrigins: []string{"https://example.com"},
+			referer:        "https://example.com/mailbox",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "origin not in trusted_origins is rejected",
+			remoteAddr:     "203.0.113.7:5000",
+			trustedOrigins: []string{"https://example.com"},
+			origin:         "https://evil.com",
+			expectedStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := &Server{
+				logger: &NilLogger{},
+				Options: &Options{
+					TrustedProxies: tt.trustedProxies,
+					TrustedOrigins: tt.trustedOrigins,
+				},
+			}
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			req.Host = "example.com"
+			req.RemoteAddr = tt.remoteAddr
+			if tt.xfProto != "" {
+				req.Header.Set("X-Forwarded-Proto", tt.xfProto)
+			}
+			if tt.xfHost != "" {
+				req.Header.Set("X-Forwarded-Host", tt.xfHost)
+			}
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+			if tt.referer != "" {
+				req.Header.Set("Referer", tt.referer)
+			}
+
+			w := httptest.NewRecorder()
+			ctx := NewContext(w, req, server)
+
+			err := handler(ctx)
+			if tt.expectedStatus == http.StatusForbidden {
+				var httpErr *HTTPError
+				assert.ErrorAs(t, err, &httpErr)
+				assert.Equal(t, http.StatusForbidden, httpErr.Code)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, http.StatusOK, w.Code)
+			}
+		})
+	}
+}
+
+func TestFirstForwardedValue(t *testing.T) {
+	assert.Equal(t, "https", firstForwardedValue("https"))
+	assert.Equal(t, "https", firstForwardedValue("https, http"))
+	assert.Equal(t, "https", firstForwardedValue("  https , http "))
+	assert.Equal(t, "", firstForwardedValue(""))
+}
+
+func TestOriginInList(t *testing.T) {
+	list := []string{"https://webmail.example.com"}
+	assert.True(t, originInList("https://webmail.example.com", list))
+	assert.True(t, originInList("HTTPS://WEBMAIL.EXAMPLE.COM", list))
+	assert.True(t, originInList("https://webmail.example.com/", list))
+	assert.False(t, originInList("http://webmail.example.com", list))
+	assert.False(t, originInList("https://evil.com", list))
+	assert.False(t, originInList("https://webmail.example.com", nil))
 }

--- a/server.go
+++ b/server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -399,6 +400,8 @@ type Options struct {
 	MaxGlobalAttachmentMiB  int                     // Max global attachment size in MiB
 	RateLimitConfig         *RateLimitConfig        // Rate limiting config, nil = use defaults
 	RateLimitEnabled        bool                    // If false, rate limiting is disabled
+	TrustedProxies          []*net.IPNet            // Proxy IPs/CIDRs whose X-Forwarded-Proto/Host headers are trusted (e.g. for CSRF origin computation behind a TLS-terminating reverse proxy)
+	TrustedOrigins          []string                // Additional origins accepted by the CSRF check (e.g. "https://webmail.example.com"), normalized to lowercase without a trailing slash
 	ReadTimeout             time.Duration           // HTTP read timeout, 0 means use default (10 seconds)
 	WriteTimeout            time.Duration           // HTTP write timeout, 0 means use default (30 seconds)
 	IdleTimeout             time.Duration           // HTTP idle timeout, 0 means use default (120 seconds)


### PR DESCRIPTION
## Problem (fixes #5)

The CSRF middleware rejects all state-changing requests (`POST`/`PUT`/`DELETE`/`PATCH`) with `403 "Invalid origin"` when alps runs behind a reverse proxy that terminates TLS and forwards to alps over plain HTTP — a very common deployment.

The expected origin was computed from the request as seen by alps:

```go
scheme := "https"
if !ctx.IsTLS() { scheme = "http" } // ctx.Request.TLS == nil behind the proxy → "http"
expectedOrigin := scheme + "://" + ctx.Request.Host
```

So alps expected `http://host` while the browser sent `Origin: https://host` → mismatch → 403. `X-Forwarded-Proto`/`X-Forwarded-Host` were never consulted, and there was no config to override the expected origin.

## Fix

- **Honor forwarded headers from trusted proxies.** `CSRFMiddleware` now uses `X-Forwarded-Proto` / `X-Forwarded-Host` to compute the expected origin **only when the immediate peer (`RemoteAddr`) is in the configured `trusted_proxies`** — mirroring the existing `X-Forwarded-For` handling used for rate limiting, so the headers can't be spoofed by untrusted clients. This makes the standard `trusted_proxies` setting "just work" behind a TLS-terminating proxy.
- **New `trusted_origins` option.** An explicit allowlist under `[server]` for deployments that can't (or don't) set forwarded headers:
  ```toml
  [server]
  trusted_origins = ["https://webmail.example.com"]
  ```
- Plumbed trusted proxies (parsed CIDRs) and trusted origins onto `alps.Options`; documented both in `config.example.toml`.

## Tests

Added `TestCSRFMiddlewareBehindProxy` (trusted vs untrusted peer, `X-Forwarded-Proto`/`Host`, comma-separated values, `trusted_origins` for both Origin and Referer, forged origin still rejected) plus `TestFirstForwardedValue` and `TestOriginInList`. Existing CSRF tests still pass.

Also verified live against a running server: a proxied HTTPS origin now passes CSRF (401 auth, not 403); an allowlisted origin passes; a forged origin is still rejected (403).

🤖 Generated with [Claude Code](https://claude.com/claude-code)