### PR TITLE
fix(carddav,caldav): route object paths that contain "/"

### DIFF
--- a/frontend/src/utils/fetch-utils.ts
+++ b/frontend/src/utils/fetch-utils.ts
@@ -1,3 +1,22 @@
+/**
+ * Encodes a value for use as a single path segment in a backend URL when the
+ * value may itself contain the `/` character — e.g. an IMAP mailbox name like
+ * Gmail's `[Gmail]/All Mail`, or a CardDAV/CalDAV object path (`.../uid.vcf`).
+ *
+ * Go's net/http.ServeMux decodes `%2F` back to `/` before routing, which would
+ * split a single-segment `{param}` wildcard and make the request 404. We
+ * therefore double-encode: the extra layer survives ServeMux's one decode as a
+ * literal `%2F` (so the segment is not split), and the backend handler undoes it
+ * with a single `url.PathUnescape`. This is a no-op for values without special
+ * characters. See GitHub issue #4.
+ *
+ * Only use this for a URL *path segment*; values sent in a request body or query
+ * string must be sent verbatim, not double-encoded.
+ */
+export function encodePathParam(value: string): string {
+  return encodeURIComponent(encodeURIComponent(value));
+}
+
 export async function fetchWithTimeout(url: RequestInfo | URL, options: RequestInit = {}, timeoutMs: number = 25000): Promise<Response> {
   const controller = new AbortController();
   const id = setTimeout(() => controller.abort(), timeoutMs);

--- a/plugins/caldav/frontend/calendar-service.ts
+++ b/plugins/caldav/frontend/calendar-service.ts
@@ -1,3 +1,5 @@
+import { encodePathParam } from '../../../frontend/src/utils/fetch-utils';
+
 export interface CalendarData {
     name: string;
     description: string;
@@ -82,7 +84,7 @@ class CalendarService {
     }
 
     async renameCalendar(path: string, name: string): Promise<{ ok: string }> {
-        const encodedPath = encodeURIComponent(path);
+        const encodedPath = encodePathParam(path);
         const response = await fetch(`/calendar/calendars/${encodedPath}`, {
             method: 'PATCH',
             headers: {
@@ -97,7 +99,7 @@ class CalendarService {
     }
 
     async deleteCalendar(path: string): Promise<{ ok: string }> {
-        const encodedPath = encodeURIComponent(path);
+        const encodedPath = encodePathParam(path);
         const response = await fetch(`/calendar/calendars/${encodedPath}`, {
             method: 'DELETE'
         });
@@ -122,7 +124,7 @@ class CalendarService {
     }
 
     async updateEvent(path: string, event: Omit<EventData, 'uid' | 'path'>): Promise<{ ok: string, path: string }> {
-        const encodedPath = encodeURIComponent(path);
+        const encodedPath = encodePathParam(path);
         const response = await fetch(`/calendar/events/${encodedPath}/edit`, {
             method: 'POST',
             headers: {
@@ -137,7 +139,7 @@ class CalendarService {
     }
 
     async deleteEvent(path: string): Promise<{ ok: string }> {
-        const encodedPath = encodeURIComponent(path);
+        const encodedPath = encodePathParam(path);
         const response = await fetch(`/calendar/events/${encodedPath}`, {
             method: 'DELETE'
         });

--- a/plugins/carddav/frontend/contacts-service.ts
+++ b/plugins/carddav/frontend/contacts-service.ts
@@ -1,4 +1,4 @@
-import { fetchWithTimeout } from '../../../frontend/src/utils/fetch-utils';
+import { fetchWithTimeout, encodePathParam } from '../../../frontend/src/utils/fetch-utils';
 
 export interface ContactPayload {
   name?: string;
@@ -27,7 +27,7 @@ class ContactsService {
   }
 
   async fetchContact(path: string) {
-    const res = await fetchWithTimeout(`/contacts/${encodeURIComponent(path)}`);
+    const res = await fetchWithTimeout(`/contacts/${encodePathParam(path)}`);
     if (!res.ok) {
       throw new Error(`Failed to fetch contact: ${res.statusText}`);
     }
@@ -47,7 +47,7 @@ class ContactsService {
   }
 
   async updateContact(path: string, payload: ContactPayload) {
-    const res = await fetchWithTimeout(`/contacts/${encodeURIComponent(path)}/edit`, {
+    const res = await fetchWithTimeout(`/contacts/${encodePathParam(path)}/edit`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)
@@ -59,7 +59,7 @@ class ContactsService {
   }
 
   async deleteContact(path: string) {
-    const res = await fetchWithTimeout(`/contacts/${encodeURIComponent(path)}`, {
+    const res = await fetchWithTimeout(`/contacts/${encodePathParam(path)}`, {
       method: 'DELETE'
     });
     if (!res.ok) {


### PR DESCRIPTION
## Problem

Same routing regression as #4, in the CardDAV/CalDAV plugins. The per-object routes use a single-segment `{path}` wildcard:

- `GET /contacts/{path}`, `POST /contacts/{path}/edit`, `DELETE /contacts/{path}`
- `PATCH|DELETE /calendar/calendars/{path}`, `POST /calendar/events/{path}/edit`, `DELETE /calendar/events/{path}`

But DAV object paths are hrefs that contain `/` (e.g. `addressbooks/user/default/uid.vcf`). The plugin frontends single-encoded the path, so `%2F` reached `net/http.ServeMux`, which decodes it to `/` before routing and splits the `{path}` segment — the request no longer matches and 404s / falls through.

## Fix

- Added a shared `encodePathParam()` helper in `frontend/src/utils/fetch-utils.ts` that double-encodes a value for use as a single URL path segment.
- Used it for the object-path segment in the CardDAV/CalDAV service calls (`contacts-service.ts`, `calendar-service.ts`). The extra encoding layer survives ServeMux's single decode as a literal `%2F`, and the handlers' existing `parseObjectPath` (`url.PathUnescape`) recovers the original href.
- Client-side hash routes (which key on category/UID, not the object path) are left unchanged.

## Validation

Frontend typechecks (the plugin frontends are covered by the main `tsconfig` include). Verified live with both plugins enabled: all six routes accept a double-encoded multi-slash path and reach their API handler (401 JSON, not the SPA fall-through); the server log shows ServeMux decoding exactly one layer to a single `%2F` segment.

Relatedly fixes the same class of bug reported for mailboxes in #4 (see #13).

> Note: the built `frontend/dist` bundle is not included in this PR; run `make build-frontend` before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)