### PR TITLE
Harden /proxy and BIMI against SSRF and SVG XSS

### DIFF
--- a/plugins/base/bimi.go
+++ b/plugins/base/bimi.go
@@ -64,7 +64,8 @@ func handleBIMIAvatar(ctx *alps.Context) error {
 
 	if data, err := os.ReadFile(cacheFile); err == nil {
 		ctx.Response.Header().Set("Content-Type", "image/svg+xml")
-		ctx.Response.Header().Set("Content-Security-Policy", "default-src 'none'")
+		ctx.Response.Header().Set("Content-Security-Policy", "default-src 'none'; sandbox")
+		ctx.Response.Header().Set("X-Content-Type-Options", "nosniff")
 		return ctx.Stream(http.StatusOK, "image/svg+xml", bytes.NewReader(data))
 	}
 
@@ -91,7 +92,10 @@ func handleBIMIAvatar(ctx *alps.Context) error {
 		return bimiNotFound(ctx, "BIMI avatar not found")
 	}
 
-	client := http.Client{Timeout: 5 * time.Second}
+	// The l= URL comes from the queried domain's DNS record, i.e. attacker
+	// influenced: fetch through the egress-safe client so it cannot be pointed
+	// at internal/metadata addresses (SSRF), and cap the body size.
+	client := newSafeHTTPClient(5 * time.Second)
 	resp, err := client.Get(bimiURL)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		os.WriteFile(negCacheFile, []byte(""), 0644)
@@ -99,7 +103,8 @@ func handleBIMIAvatar(ctx *alps.Context) error {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	const maxBIMISize = 1 * 1024 * 1024 // 1 MiB cap
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBIMISize))
 	if err != nil {
 		os.WriteFile(negCacheFile, []byte(""), 0644)
 		return bimiNotFound(ctx, "BIMI avatar not found")
@@ -109,7 +114,8 @@ func handleBIMIAvatar(ctx *alps.Context) error {
 	os.WriteFile(cacheFile, sanitized, 0644)
 
 	ctx.Response.Header().Set("Content-Type", "image/svg+xml")
-	ctx.Response.Header().Set("Content-Security-Policy", "default-src 'none'")
+	ctx.Response.Header().Set("Content-Security-Policy", "default-src 'none'; sandbox")
+	ctx.Response.Header().Set("X-Content-Type-Options", "nosniff")
 	return ctx.Stream(http.StatusOK, "image/svg+xml", bytes.NewReader(sanitized))
 }
 

--- a/plugins/base/routes.go
+++ b/plugins/base/routes.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/emersion/go-imap/v2"
 	"github.com/emersion/go-message"
@@ -2539,11 +2540,18 @@ func handleProxy(ctx *alps.Context) error {
 		return alps.NewHTTPError(http.StatusBadRequest, "invalid url")
 	}
 
-	resp, err := http.Get(u.String())
+	// Fetch through the egress-safe client: attacker-influenced URL, so block
+	// internal/metadata addresses, bound with timeouts, and cap redirects.
+	client := newSafeHTTPClient(20 * time.Second)
+	resp, err := client.Get(u.String())
 	if err != nil {
-		return err
+		return alps.NewHTTPError(http.StatusBadGateway, "failed to fetch resource")
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return alps.NewHTTPError(http.StatusBadGateway, "failed to fetch resource")
+	}
 
 	mediaType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
 	if err != nil {
@@ -2570,6 +2578,14 @@ func handleProxy(ctx *alps.Context) error {
 		}
 		ctx.Response.Header().Set("Content-Length", strconv.Itoa(size))
 	}
+
+	// The upstream body is untrusted. Proxied content is only ever consumed as a
+	// subresource (img/link/font) from inside the sandboxed message iframe, so
+	// prevent it from being rendered as an active document if fetched directly:
+	// SVGs with inline scripts must not execute in this origin.
+	ctx.Response.Header().Set("Content-Security-Policy", "default-src 'none'; sandbox")
+	ctx.Response.Header().Set("X-Content-Type-Options", "nosniff")
+	ctx.Response.Header().Set("Content-Disposition", "attachment")
 
 	lr := io.LimitedReader{R: resp.Body, N: int64(maxSize)}
 	return ctx.Stream(http.StatusOK, mediaType, &lr)

--- a/plugins/base/safehttp.go
+++ b/plugins/base/safehttp.go
@@ -1,0 +1,96 @@
+package alpsbase
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"syscall"
+	"time"
+)
+
+// errBlockedAddress is returned when an outbound fetch (remote-content proxy,
+// BIMI avatar) resolves to a non-public address. These endpoints fetch
+// attacker-influenced URLs, so they must not be usable to reach loopback,
+// private, link-local (cloud metadata), or other internal ranges (SSRF).
+var errBlockedAddress = errors.New("destination address is not permitted")
+
+// extraBlockedCIDRs covers ranges not classified by the net.IP helpers below
+// but still unsafe as SSRF targets (carrier-grade NAT and reserved space).
+var extraBlockedCIDRs = func() []*net.IPNet {
+	var nets []*net.IPNet
+	for _, cidr := range []string{
+		"100.64.0.0/10", // RFC 6598 carrier-grade NAT
+		"192.0.0.0/24",  // IETF protocol assignments
+		"198.18.0.0/15", // RFC 2544 benchmarking
+		"240.0.0.0/4",   // reserved
+	} {
+		if _, n, err := net.ParseCIDR(cidr); err == nil {
+			nets = append(nets, n)
+		}
+	}
+	return nets
+}()
+
+// isDisallowedIP reports whether an IP must not be dialed by the safe client.
+func isDisallowedIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsMulticast() {
+		return true
+	}
+	for _, n := range extraBlockedCIDRs {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// safeDialControl runs after DNS resolution, on the concrete address that will
+// be connected to. Validating the resolved IP here (rather than the URL host)
+// defeats DNS rebinding and redirect-to-internal-IP tricks.
+func safeDialControl(network, address string, _ syscall.RawConn) error {
+	if network != "tcp4" && network != "tcp6" && network != "tcp" {
+		return errBlockedAddress
+	}
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return err
+	}
+	if isDisallowedIP(net.ParseIP(host)) {
+		return errBlockedAddress
+	}
+	return nil
+}
+
+// newSafeHTTPClient returns an http.Client for fetching attacker-influenced
+// URLs: it blocks non-public destinations at dial time, bounds every phase
+// with timeouts, and caps redirects (re-validating the scheme on each hop).
+func newSafeHTTPClient(timeout time.Duration) *http.Client {
+	dialer := &net.Dialer{
+		Timeout: 10 * time.Second,
+		Control: safeDialControl,
+	}
+	transport := &http.Transport{
+		DialContext:           dialer.DialContext,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 15 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		DisableKeepAlives:     true,
+	}
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return errors.New("too many redirects")
+			}
+			if req.URL.Scheme != "http" && req.URL.Scheme != "https" {
+				return errBlockedAddress
+			}
+			return nil
+		},
+	}
+}


### PR DESCRIPTION
## Problem

Two endpoints fetch **attacker-influenced URLs** with the default HTTP client:

- **`/proxy?url=…`** ([routes.go](../blob/main/plugins/base/routes.go)) — used to load remote images/CSS/fonts referenced by mail. It called `http.Get` (no timeout, follows redirects to any host, no egress filter) and streamed the upstream body **inline** with no security headers. Its content-type allowlist includes the prefix `"image/"`, which matches `image/svg+xml`, so opening `/proxy?url=https://attacker/x.svg` (an SVG with an inline `<script>`) rendered a scripted document in the webmail origin → **XSS**. It was also a general **SSRF** (`?url=http://169.254.169.254/…`, internal hosts, port probing).
- **`/bimi/avatar`** ([bimi.go](../blob/main/plugins/base/bimi.go)) — fetches the `l=` URL from the queried domain's `_bimi` DNS TXT record and returns the body. The `https://` gate was bypassable via a redirect to an internal `http://` address, making it a read-SSRF.

## Fix

- New `plugins/base/safehttp.go`: a shared **egress-safe HTTP client**. A `net.Dialer.Control` hook validates the **resolved IP** at connect time and rejects loopback / private / link-local (metadata) / CGNAT / reserved ranges — evaluating the concrete dial address defeats DNS rebinding and redirect-to-internal. It bounds connect/TLS/response-header phases with timeouts and caps redirects (re-checking the scheme each hop).
- Route both `/proxy` and BIMI through it; cap the BIMI body at 1 MiB.
- Serve proxied bytes with `Content-Security-Policy: default-src 'none'; sandbox`, `X-Content-Type-Options: nosniff`, and `Content-Disposition: attachment` so untrusted content can't render as an active document. Legitimate use (img/link/font **subresources** inside the sandboxed message iframe) ignores `Content-Disposition` and is unaffected. Added CSP `sandbox` + `nosniff` to the BIMI SVG responses too.
- `/proxy` now returns a generic **502** on fetch failure / non-200 instead of leaking the transport error or streaming an error body.

## Verification

- `go build ./...`, `go vet`, and `go test ./plugins/base/` pass; cross-compiles clean for `linux/amd64` and `freebsd/amd64` (the `syscall.RawConn` dialer control is portable).
- Legitimate remote-content loading (images/CSS/fonts as subresources) is preserved; only direct/navigational rendering of proxied content is blocked.

Note: the BIMI regex SVG sanitizer remains weak but is now defense-in-depth behind `default-src 'none'; sandbox` + `nosniff`; a real SVG sanitizer is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)