### PR TITLE
Apply security headers to all responses (fix CSP not reaching the SPA)

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -275,8 +275,27 @@ func (r *Router) wrapHandler(h HandlerFunc) http.HandlerFunc {
 	}
 }
 
+// setSecurityHeaders applies baseline security headers to every response.
+// It runs here, at the single request choke point, rather than as Use/Pre
+// middleware because static file handlers (StaticFS/Static) are registered
+// directly on the mux and bypass the middleware chain — so the SPA shell and
+// all JS/CSS bundles would otherwise be served with no CSP at all. Handlers may
+// still override these with a stricter policy after dispatch (e.g. the BIMI and
+// /proxy endpoints set `default-src 'none'`); Set() replaces, so the stricter
+// value wins.
+func setSecurityHeaders(h http.Header) {
+	// `style-src 'unsafe-inline'` is required for e-mails with embedded stylesheets.
+	// `img-src`/`font-src data:` are required for placeholder resources in sandboxed iframes.
+	h.Set("Content-Security-Policy", "default-src 'self'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self' 'unsafe-inline'")
+	// DNS prefetching has privacy implications.
+	h.Set("X-DNS-Prefetch-Control", "off")
+	// Never allow browsers to MIME-sniff a response away from its declared type.
+	h.Set("X-Content-Type-Options", "nosniff")
+}
+
 // ServeHTTP implements http.Handler.
 func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	setSecurityHeaders(w.Header())
 	r.mux.ServeHTTP(w, req)
 }
 

--- a/middleware_router_test.go
+++ b/middleware_router_test.go
@@ -6,9 +6,44 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// TestSecurityHeadersAppliedToStaticAssets verifies that baseline security
+// headers reach every response, including static files served via StaticFS.
+// StaticFS registers its handler directly on the mux, bypassing the Use/Pre
+// middleware chain, so headers set only there would never reach the SPA shell
+// or JS/CSS bundles — the document where CSP actually matters.
+func TestSecurityHeadersAppliedToStaticAssets(t *testing.T) {
+	server := &Server{logger: &NilLogger{}}
+	router := NewRouter(server)
+
+	router.GET("/api/thing", func(ctx *Context) error {
+		return ctx.String(http.StatusOK, "ok")
+	})
+	router.StaticFS("", http.FS(fstest.MapFS{
+		"index.html": &fstest.MapFile{Data: []byte("<!doctype html>")},
+		"app.js":     &fstest.MapFile{Data: []byte("console.log(1)")},
+	}))
+
+	for _, path := range []string{"/api/thing", "/", "/app.js"} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.NotEmpty(t, w.Header().Get("Content-Security-Policy"),
+				"CSP must be set on %q, including static assets", path)
+			assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"),
+				"nosniff must be set on %q", path)
+			assert.Equal(t, "off", w.Header().Get("X-DNS-Prefetch-Control"),
+				"DNS-prefetch header must be set on %q", path)
+		})
+	}
+}
 
 // encodeURIComponentJS mimics JavaScript's encodeURIComponent: it percent-encodes
 // every byte except the unreserved set A-Za-z0-9 and -_.!~*'(). Notably it uses

--- a/server.go
+++ b/server.go
@@ -449,17 +449,9 @@ type PluginConfig struct {
 // setupMiddleware registers middleware on the router.
 // This is called both during initial setup and during reload.
 func (s *Server) setupMiddleware(router *Router) {
-	// Security headers middleware
-	router.Use(func(next HandlerFunc) HandlerFunc {
-		return func(ctx *Context) error {
-			// `style-src 'unsafe-inline'` is required for e-mails with embedded stylesheets
-			// `img-src data:` and `font-src data:` are required for placeholder resources in sandboxed iframes
-			ctx.Response.Header().Set("Content-Security-Policy", "default-src 'self'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self' 'unsafe-inline'")
-			// DNS prefetching has privacy implications
-			ctx.Response.Header().Set("X-DNS-Prefetch-Control", "off")
-			return next(ctx)
-		}
-	})
+	// Baseline security headers (CSP, nosniff, DNS-prefetch) are applied to every
+	// response in Router.ServeHTTP so they also cover static assets (the SPA shell
+	// and JS/CSS bundles) served directly on the mux, which bypass this chain.
 
 	// CSRF protection middleware (validates Origin/Referer for state-changing requests)
 	router.Use(CSRFMiddleware)


### PR DESCRIPTION
## Problem

Security headers (CSP, `X-DNS-Prefetch-Control`) were registered as a `Use` middleware, which only runs inside `wrapHandler` — i.e. for routes registered via `Router.Add`/`GET`/`POST`. But `StaticFS`/`Static` register their file server **directly on the mux** (`r.mux.Handle`), bypassing the middleware chain entirely.

The SPA uses hash routing, so every real navigation loads `index.html` from the static file server. That document — the one that hosts all client-side rendering and the place a CSP would actually constrain script injection — was served with **no `Content-Security-Policy` at all**. The header only ever landed on JSON API responses, where it accomplishes nothing.

## Fix

Move the baseline security headers into `Router.ServeHTTP`, the single choke point every request passes through (`Server.ServeHTTP → Router.ServeHTTP → mux`). Now static assets and dynamic routes are covered uniformly.

- Handlers may still tighten the policy after dispatch (the BIMI and `/proxy` endpoints set `default-src 'none'`); `Header().Set()` replaces, so the stricter value wins.
- Removed the now-redundant `Use` middleware.
- Added `X-Content-Type-Options: nosniff` globally (defense-in-depth flagged in review).

## Verification

- `go build ./...`, `go vet ./...`, full root `go test` pass.
- New `TestSecurityHeadersAppliedToStaticAssets` asserts CSP + nosniff + DNS-prefetch headers are present on a dynamic route **and** on `/` and `/app.js` served via `StaticFS` (this test fails against the old code).

This closes the loop with #15 and #16: those remove the XSS sinks, this restores the CSP backstop for the document that hosts them. Tightening the policy value itself (dropping `script-src 'unsafe-inline'`) is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)