### PR TITLE
Fix X-Forwarded-For parsing in rate limiter (anti-spoofing)

### DIFF
--- a/ratelimit.go
+++ b/ratelimit.go
@@ -354,8 +354,30 @@ func filterTimestamps(timestamps []time.Time, cutoff time.Time) []time.Time {
 	return filtered
 }
 
-// getClientIP extracts the real client IP from the request
-// Handles X-Forwarded-For, X-Real-IP headers if remote address is a trusted proxy
+// isTrustedProxyIP reports whether ip falls within one of the configured
+// trusted-proxy CIDRs.
+func isTrustedProxyIP(ip net.IP, trustedProxies []*net.IPNet) bool {
+	if ip == nil {
+		return false
+	}
+	for _, cidr := range trustedProxies {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// getClientIP extracts the real client IP from the request.
+//
+// X-Forwarded-For is a list appended to by each proxy in the chain, so the
+// LEFT entries are client-supplied and spoofable while the RIGHT entries were
+// added by our own infrastructure. We therefore only consult forwarded headers
+// when the immediate peer is a trusted proxy, and we walk X-Forwarded-For from
+// right to left, skipping our own trusted-proxy hops, and return the first
+// address that is not a trusted proxy — the closest client we can vouch for.
+// Taking the leftmost entry (as before) let a client set an arbitrary IP to
+// dodge per-IP limits or lock out a victim's IP.
 func getClientIP(r *http.Request, trustedProxies []*net.IPNet) string {
 	remoteIPStr, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
@@ -364,30 +386,38 @@ func getClientIP(r *http.Request, trustedProxies []*net.IPNet) string {
 
 	isTrustedProxy := false
 	if len(trustedProxies) > 0 {
-		remoteIP := net.ParseIP(remoteIPStr)
-		if remoteIP != nil {
-			for _, cidr := range trustedProxies {
-				if cidr.Contains(remoteIP) {
-					isTrustedProxy = true
-					break
-				}
-			}
-		}
+		isTrustedProxy = isTrustedProxyIP(net.ParseIP(remoteIPStr), trustedProxies)
 	}
 
 	if isTrustedProxy {
-		// Check X-Forwarded-For header (comma-separated list, first is client)
 		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
 			parts := strings.Split(xff, ",")
-			ip := strings.TrimSpace(parts[0])
-			if ipWithoutPort, _, err := net.SplitHostPort(ip); err == nil {
-				return ipWithoutPort
+			for i := len(parts) - 1; i >= 0; i-- {
+				candidate := strings.TrimSpace(parts[i])
+				if candidate == "" {
+					continue
+				}
+				if host, _, err := net.SplitHostPort(candidate); err == nil {
+					candidate = host
+				}
+				ip := net.ParseIP(candidate)
+				if ip == nil {
+					// An unparseable rightmost hop cannot be verified; stop rather
+					// than trusting anything further left (which is client-supplied).
+					break
+				}
+				if isTrustedProxyIP(ip, trustedProxies) {
+					continue // our own proxy hop; keep walking left
+				}
+				return candidate // first non-proxy from the right = real client
 			}
-			return ip
 		}
 
-		// Check X-Real-IP header
-		if xri := r.Header.Get("X-Real-IP"); xri != "" {
+		// X-Real-IP is set by the trusted proxy to a single client address.
+		if xri := strings.TrimSpace(r.Header.Get("X-Real-IP")); xri != "" {
+			if host, _, err := net.SplitHostPort(xri); err == nil {
+				return host
+			}
 			return xri
 		}
 	}

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -290,6 +290,77 @@ func TestRateLimiter_XForwardedForHandling(t *testing.T) {
 	}
 }
 
+// TestRateLimiter_XForwardedForSpoofResistant verifies that a client cannot
+// escape per-IP limits by prepending a forged X-Forwarded-For entry. The proxy
+// appends the real client IP on the right; getClientIP must walk right-to-left
+// past trusted-proxy hops and return that real IP, ignoring the spoofed left
+// entries — so every attempt lands in the same bucket regardless of the forged
+// value.
+func TestRateLimiter_XForwardedForSpoofResistant(t *testing.T) {
+	logger := &mockLogger{}
+	config := DefaultRateLimitConfig()
+	config.IPRequestsPerMinute = 2
+	// Two internal proxies in the chain, both trusted.
+	_, edge, _ := net.ParseCIDR("10.0.0.1/32")
+	_, inner, _ := net.ParseCIDR("10.0.0.2/32")
+	config.TrustedProxies = []*net.IPNet{edge, inner}
+
+	rl := NewRateLimiter(config, logger, nil)
+	defer rl.Close()
+
+	// Each request forges a *different* leftmost XFF entry but is really the same
+	// client (203.0.113.50), appended by the inner proxy 10.0.0.2, then by the
+	// edge proxy 10.0.0.1 (the direct peer).
+	makeReq := func(spoof string) *http.Request {
+		req := httptest.NewRequest("POST", "/session", nil)
+		req.RemoteAddr = "10.0.0.1:12345" // edge proxy (trusted)
+		req.Header.Set("X-Forwarded-For", spoof+", 203.0.113.50, 10.0.0.2")
+		return req
+	}
+
+	req1 := makeReq("1.2.3.4")
+	req2 := makeReq("5.6.7.8")
+	req3 := makeReq("9.10.11.12")
+
+	if allowed, _, _ := rl.CheckLoginAllowed(req1, "user@example.com"); !allowed {
+		t.Fatal("first request should be allowed")
+	}
+	rl.RecordLoginAttempt(req1, "user@example.com", false)
+
+	if allowed, _, _ := rl.CheckLoginAllowed(req2, "user@example.com"); !allowed {
+		t.Fatal("second request should be allowed")
+	}
+	rl.RecordLoginAttempt(req2, "user@example.com", false)
+
+	// Despite different forged left entries, all three resolve to 203.0.113.50,
+	// so the third exceeds the per-minute cap.
+	if allowed, _, _ := rl.CheckLoginAllowed(req3, "user@example.com"); allowed {
+		t.Error("third request should be rate limited: spoofed XFF must not create a fresh IP bucket")
+	}
+
+	// Sanity: getClientIP resolves the real appended client, not the spoof.
+	if got := getClientIP(req1, config.TrustedProxies); got != "203.0.113.50" {
+		t.Errorf("getClientIP = %q, want 203.0.113.50 (real client, not spoofed left entry)", got)
+	}
+}
+
+// TestRateLimiter_XForwardedForUntrustedPeerIgnored verifies that when the
+// direct peer is NOT a trusted proxy, forwarded headers are ignored entirely
+// and the peer's real address is used.
+func TestRateLimiter_XForwardedForUntrustedPeerIgnored(t *testing.T) {
+	config := DefaultRateLimitConfig()
+	_, trusted, _ := net.ParseCIDR("10.0.0.1/32")
+	config.TrustedProxies = []*net.IPNet{trusted}
+
+	req := httptest.NewRequest("POST", "/session", nil)
+	req.RemoteAddr = "198.51.100.9:5555" // arbitrary client, not a trusted proxy
+	req.Header.Set("X-Forwarded-For", "203.0.113.50")
+
+	if got := getClientIP(req, config.TrustedProxies); got != "198.51.100.9" {
+		t.Errorf("getClientIP = %q, want 198.51.100.9 (forged XFF from untrusted peer must be ignored)", got)
+	}
+}
+
 func TestRateLimiter_XRealIPHandling(t *testing.T) {
 	logger := &mockLogger{}
 	config := DefaultRateLimitConfig()


### PR DESCRIPTION
## Problem

`getClientIP` took the **leftmost** `X-Forwarded-For` entry as the client IP whenever the direct peer was a trusted proxy:

```go
parts := strings.Split(xff, ",")
ip := strings.TrimSpace(parts[0]) // leftmost = client-supplied
```

But the left entries of XFF are appended by the client and everything to the left of our own infrastructure is spoofable. Two concrete attacks against the per-IP brute-force limits (5/min, 20/hour):

1. **Bypass:** rotate `X-Forwarded-For: <random>` each attempt → a fresh IP bucket per request, so the per-IP limit never trips.
2. **Victim lockout (DoS):** send `X-Forwarded-For: <victim-ip>` and burn the quota → the victim's IP is locked out for 15 minutes.

## Fix

Walk `X-Forwarded-For` **right-to-left**, skipping our own trusted-proxy hops, and return the first entry that is not a trusted proxy — the closest client we can actually vouch for. This mirrors how the CSRF middleware already restricts trust to the immediate peer.

- Forwarded headers are still only consulted when the immediate peer is a trusted proxy.
- An unparseable rightmost hop stops the walk rather than trusting client-supplied entries further left.
- `X-Real-IP` handling preserved (now strips an optional port).

## Verification

- `go build`, `go vet`, and all `TestRateLimiter_*` pass.
- Existing `TestRateLimiter_XForwardedForHandling` / `_XRealIPHandling` still pass unchanged (single-entry legit case: rightmost == the only entry).
- New `TestRateLimiter_XForwardedForSpoofResistant`: three requests with **different** forged left entries but the same proxy-appended real IP all land in one bucket → the third is limited (fails against the old code).
- New `TestRateLimiter_XForwardedForUntrustedPeerIgnored`: a forged XFF from a non-proxy peer is ignored; the peer's real address is used.

Note: this requires all internal proxies in the chain to be listed in `trusted_proxies` (standard requirement for correct right-to-left resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)