### PR TITLE
ManageSieve: require TLS before sending credentials (fix STARTTLS downgrade)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -391,7 +391,11 @@ enabled = true
 # ManageSieve plugin for email filtering
 enabled = true
 # ManageSieve server URL (optional, can use auto-discovery via SRV records)
-# Supported schemes: managesieves://, managesieve+insecure://, managesieve://, sieve://
+# Supported schemes: managesieves://, managesieve://, sieve://, managesieve+insecure://
+# TLS is required: the connection must be upgraded via STARTTLS before the
+# account password is sent. If the server does not offer STARTTLS the connection
+# is refused. Use managesieve+insecure:// only for a trusted/local server without
+# TLS — it permits cleartext authentication and skips certificate verification.
 # server = "managesieves://sieve.example.com:4190"
 
 

--- a/plugins/managesieve/plugin.go
+++ b/plugins/managesieve/plugin.go
@@ -10,6 +10,10 @@ import (
 type plugin struct {
 	alps.GoPlugin
 	url *url.URL
+	// insecure allows sending credentials over an unencrypted connection when
+	// the server does not offer STARTTLS. Only enabled by the explicit
+	// managesieve+insecure:// scheme; otherwise TLS is required.
+	insecure bool
 }
 
 func newPlugin(srv *alps.Server) (alps.Plugin, error) {
@@ -23,11 +27,22 @@ func newPlugin(srv *alps.Server) (alps.Plugin, error) {
 		return nil, fmt.Errorf("failed to parse ManageSieve server: %v", err)
 	}
 
+	insecure := false
+	switch u.Scheme {
+	case "managesieves", "managesieve", "sieve", "":
+		// TLS required (STARTTLS must succeed before authenticating).
+	case "managesieve+insecure", "sieve+insecure":
+		insecure = true
+	default:
+		return nil, fmt.Errorf("unknown scheme for ManageSieve server: %q (use managesieves://, managesieve://, or managesieve+insecure://)", u.Scheme)
+	}
+
 	srv.Logger().Printf("Configured ManageSieve server: %v", u)
 
 	p := &plugin{
 		GoPlugin: alps.GoPlugin{Name: "managesieve"},
 		url:      u,
+		insecure: insecure,
 	}
 
 	p.GET("/managesieve/script", p.handleGetScript)

--- a/plugins/managesieve/routes.go
+++ b/plugins/managesieve/routes.go
@@ -52,13 +52,22 @@ func (p *plugin) connectClient(ctx *alps.Context) (*MSClient, error) {
 		c.SetDebug(os.Stdout)
 	}
 
-	// Upgrade to TLS if supported
+	// Upgrade to TLS before authenticating. Credentials are sent as SASL PLAIN,
+	// so a plaintext connection would disclose the account password. Require
+	// STARTTLS unless the operator explicitly opted into insecure mode; do not
+	// silently fall back to cleartext just because the (unauthenticated,
+	// spoofable) capability list omits STARTTLS — that is a downgrade attack.
 	if _, ok := c.capabilities["STARTTLS"]; ok {
 		host, _, _ := strings.Cut(addr, ":")
-		if err := c.StartTLS(&tls.Config{ServerName: host}); err != nil {
+		if err := c.StartTLS(&tls.Config{ServerName: host, InsecureSkipVerify: p.insecure}); err != nil {
 			c.Close()
 			return nil, fmt.Errorf("STARTTLS failed: %w", err)
 		}
+	} else if !p.insecure {
+		c.Close()
+		return nil, fmt.Errorf("ManageSieve server does not offer STARTTLS; refusing to send credentials over an unencrypted connection (use the managesieve+insecure:// scheme to override)")
+	} else {
+		ctx.Server.Logger().Printf("WARNING: ManageSieve connecting without TLS (insecure scheme); credentials are sent in cleartext")
 	}
 
 	// Authenticate


### PR DESCRIPTION
## Problem

`connectClient` opened a plaintext ManageSieve connection and upgraded to TLS **only if** the server's initial capability list advertised `STARTTLS`; otherwise it proceeded directly to SASL `PLAIN` — sending the account password in cleartext:

```go
if _, ok := c.capabilities["STARTTLS"]; ok {
    c.StartTLS(...)
}
auth := sasl.NewPlainClient("", username, ctx.Session.Password())
```

That capability list is exchanged **before** TLS and is unauthenticated, so an on-path attacker can strip `STARTTLS` from it to force the password onto the wire in the clear (a classic STARTTLS downgrade). A server that simply doesn't advertise STARTTLS also caused silent cleartext auth.

## Fix

Require STARTTLS to succeed before authenticating. If the server does not offer STARTTLS, the connection is **refused** rather than falling back to cleartext.

- The explicit `managesieve+insecure://` (or `sieve+insecure://`) scheme opts out: it permits cleartext auth and skips certificate verification, for a trusted/local server without TLS.
- Schemes are now parsed and validated at startup (`managesieves`, `managesieve`, `sieve`, empty → TLS required; `*+insecure` → insecure; anything else → error).
- The example config documents the TLS requirement and the opt-out.

## Compatibility

Migadu-style `managesieves://host:4190` keeps working — the code already reached TLS via STARTTLS on 4190, and STARTTLS still succeeds there. Only the **silent plaintext fallback** is removed. Deployments that genuinely talk to a local sieve server without TLS must switch to `managesieve+insecure://` (a deliberate, documented change).

## Verification

- `go build ./...`, `go vet`, and `go test ./plugins/managesieve/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)