### PR TITLE
Unify session teardown (fix attachment leak, timer deadlock, close races)

### DIFF
--- a/session.go
+++ b/session.go
@@ -91,6 +91,9 @@ type Session struct {
 	memoryData     map[string]interface{}
 
 	lastAccess atomic.Int64 // stores unix nano for LRU eviction
+
+	closeOnce    sync.Once // guards close(s.closed)
+	teardownOnce sync.Once // guards releasing attachments/provider/cache
 }
 
 type Attachment struct {
@@ -292,23 +295,47 @@ func (s *Session) SetHTTPBasicAuth(req *http.Request) {
 	req.SetBasicAuth(s.username, s.password)
 }
 
-// Close destroys the session. This can be used to log the user out.
+// teardown releases every resource the session owns: composer attachments (and
+// their global-budget accounting), the mail provider connection, and the cache.
+// It is idempotent and safe to call from multiple goroutines — only the first
+// call does the work — so every exit path (logout, eviction, natural expiry)
+// can call it without risking a double free or a leaked resource. Previously
+// each exit path cleaned up a different subset, which is how expiring sessions
+// leaked their attachments and permanently inflated the global budget.
+func (s *Session) teardown() {
+	s.teardownOnce.Do(func() {
+		s.attachmentsLocker.Lock()
+		for _, f := range s.attachments {
+			f.Form.RemoveAll()
+			s.manager.globalAttachmentSize.Add(-f.File.Size)
+		}
+		s.attachments = make(map[string]*Attachment)
+		s.attachmentsLocker.Unlock()
+
+		s.providerLocker.Lock()
+		if s.provider != nil {
+			s.provider.Close()
+			s.provider = nil
+		}
+		s.providerLocker.Unlock()
+
+		if s.cache != nil {
+			s.cache.Close()
+		}
+	})
+}
+
+// Close destroys the session. This can be used to log the user out. It signals
+// the timeout goroutine to exit, which then runs teardown() to release the
+// session's resources. Teardown is deliberately left to the goroutine (which
+// runs it before taking sm.locker) so that closing the provider — potentially
+// blocking on an in-flight mail operation — never happens while a caller holds
+// sm.locker (e.g. eviction), which would stall every other session. Close is
+// safe to call more than once and from multiple goroutines concurrently.
 func (s *Session) Close() {
-	s.attachmentsLocker.Lock()
-	defer s.attachmentsLocker.Unlock()
-
-	for _, f := range s.attachments {
-		f.Form.RemoveAll()
-		s.manager.globalAttachmentSize.Add(-f.File.Size)
-	}
-	s.attachments = make(map[string]*Attachment)
-
-	select {
-	case <-s.closed:
-		// This space is intentionally left blank
-	default:
+	s.closeOnce.Do(func() {
 		close(s.closed)
-	}
+	})
 }
 
 // Puts an attachment and returns a generated UUID
@@ -519,7 +546,18 @@ func newSessionManager(connectProviderFunc provider.AuthenticatedProviderFactory
 }
 
 func (sm *SessionManager) Close() {
+	// Snapshot the sessions under the lock, then close them without holding it.
+	// Each Close() wakes the session's timeout goroutine, which removes itself
+	// from sm.sessions under the same lock; iterating the live map here would be
+	// a concurrent map iteration/write and crash the process during shutdown.
+	sm.locker.Lock()
+	sessions := make([]*Session, 0, len(sm.sessions))
 	for _, s := range sm.sessions {
+		sessions = append(sessions, s)
+	}
+	sm.locker.Unlock()
+
+	for _, s := range sessions {
 		s.Close()
 	}
 }
@@ -804,20 +842,21 @@ func (sm *SessionManager) Put(username, password string) (*Session, error) {
 			}
 		}()
 		timer := time.NewTimer(s.duration)
+		defer timer.Stop()
 
 		alive := true
 		for alive {
 			select {
 			case <-s.pings:
-				if !timer.Stop() {
-					<-timer.C
-				}
+				// Go 1.23+ timer channels are unbuffered and Stop guarantees no
+				// stale value is delivered afterwards, so the old drain pattern
+				// (`if !timer.Stop() { <-timer.C }`) is unnecessary and can now
+				// deadlock if the timer fires as a ping arrives.
+				timer.Stop()
 				timer.Reset(s.duration)
 			case newDuration := <-s.durationUpdate:
 				s.duration = newDuration
-				if !timer.Stop() {
-					<-timer.C
-				}
+				timer.Stop()
 				timer.Reset(s.duration)
 			case <-timer.C:
 				alive = false
@@ -826,18 +865,9 @@ func (sm *SessionManager) Put(username, password string) (*Session, error) {
 			}
 		}
 
-		timer.Stop()
-
-		s.providerLocker.Lock()
-		if s.provider != nil {
-			s.provider.Close()
-		}
-		s.providerLocker.Unlock()
-
-		// Unregister cache from global cleanup manager
-		if s.cache != nil {
-			s.cache.Close()
-		}
+		// Release all resources (attachments — including natural expiry, which
+		// previously leaked them — the provider connection, and the cache).
+		s.teardown()
 
 		sm.locker.Lock()
 		sm.removeSession(token)

--- a/session_test.go
+++ b/session_test.go
@@ -1,6 +1,8 @@
 package alps
 
 import (
+	"mime/multipart"
+	"sync"
 	"testing"
 	"time"
 
@@ -9,6 +11,98 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
+
+// TestSession_CloseIsIdempotent verifies that Close can be called repeatedly and
+// concurrently without panicking on a double close of the signalling channel.
+func TestSession_CloseIsIdempotent(t *testing.T) {
+	sm := &SessionManager{
+		sessions:     make(map[string]*Session),
+		userSessions: make(map[string][]string),
+	}
+	s := &Session{manager: sm, closed: make(chan struct{})}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.Close()
+		}()
+	}
+	wg.Wait()
+	s.Close() // once more, still safe
+
+	select {
+	case <-s.closed:
+	default:
+		t.Fatal("closed channel should be closed after Close()")
+	}
+}
+
+// TestSession_ExpiryReleasesAttachments verifies that a session expiring
+// naturally (timer fires) releases its composer attachments and returns their
+// bytes to the global budget — previously only the logout/eviction path did
+// this, so idle-expired sessions permanently inflated the global budget.
+func TestSession_ExpiryReleasesAttachments(t *testing.T) {
+	mockProvider := &provider.MockProvider{}
+	mockStore := &provider.MockStore{}
+	mockProvider.On("Close").Return(nil)
+	mockProvider.On("GetStore").Return(mockStore, nil)
+	mockStore.On("Get", mock.Anything, mock.Anything).Return(provider.ErrNoStoreEntry)
+
+	connectProvider := func(username, password string) (provider.MailProvider, error) {
+		return mockProvider, nil
+	}
+	var loginKey fernet.Key
+	loginKey.Generate()
+
+	sm := newSessionManager(
+		connectProvider,
+		nil,
+		&NilLogger{},
+		10*time.Minute,
+		false,
+		&loginKey,
+		200*time.Millisecond, // short session duration → quick natural expiry
+		24*time.Hour,
+		100,
+		10,
+		32,
+		128,
+		1024,
+	)
+
+	session, err := sm.Put("user@example.com", "pass")
+	assert.NoError(t, err)
+
+	// Attach a composer attachment and account for it in the global budget,
+	// well before the 200ms timer can fire.
+	form := &multipart.Form{Value: map[string][]string{}, File: map[string][]*multipart.FileHeader{}}
+	session.attachmentsLocker.Lock()
+	session.attachments["att1"] = &Attachment{
+		ComposerID: "c1",
+		File:       &multipart.FileHeader{Size: 4096},
+		Form:       form,
+		CreatedAt:  time.Now(),
+	}
+	session.attachmentsLocker.Unlock()
+	sm.globalAttachmentSize.Add(4096)
+	token := session.Token()
+
+	// Wait for the session to expire naturally.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, gerr := sm.Get(token); gerr == ErrSessionExpired {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	_, err = sm.Get(token)
+	assert.Equal(t, ErrSessionExpired, err, "expired session must be removed from the manager")
+	assert.Equal(t, int64(0), sm.globalAttachmentSize.Load(),
+		"natural expiry must release the attachment's global budget")
+}
 
 func TestSessionManager_PutAndGet(t *testing.T) {
 	mockProvider := &provider.MockProvider{}


### PR DESCRIPTION
## Problem

Session lifecycle was distributed across four uncoordinated exit paths (the timeout goroutine, `Session.Close`, `removeSession`, and the eviction helpers), each cleaning up a *different subset* of resources. That fragmentation caused several bugs:

- **Attachment leak on expiry (high).** The timeout goroutine, on natural expiry, closed the provider and cache but **never released composer attachments** the way `Close` did. Idle-expired sessions permanently inflated `globalAttachmentSize`; over time the 1 GiB global budget fills with phantom bytes and **every attachment upload fails server-wide until restart**.
- **Timer drain deadlock (high).** The `if !timer.Stop() { <-timer.C }` pattern blocks forever under Go 1.23+ (unbuffered timer channels; `Stop` guarantees no stale value) if the timer fires just as a ping arrives — leaking an immortal, never-expiring session.
- **Double close (medium).** `Close` used a check-then-act on `s.closed`; two concurrent closes (logout racing eviction) could both hit `close()` → panic `close of closed channel`.
- **Shutdown crash (medium).** `SessionManager.Close` iterated the sessions map **without the lock** while each `Close` woke a goroutine that deleted from it — a concurrent map iteration/write that crashes the process during shutdown.

## Fix

One idempotent `teardown()` (guarded by `sync.Once`) releases attachments (with budget accounting), the provider connection, and the cache. The timeout goroutine calls it on **every** exit — expiry or signal — so attachments are always freed.

- `Close()` now only **signals** (a `sync.Once`-guarded `close(s.closed)`) and leaves teardown to the goroutine. The goroutine runs `teardown()` **before** taking `sm.locker`, so closing the provider (which can block on an in-flight mail op) never stalls `sm.locker` during eviction — preserving the original async-provider-close semantics while fixing the leak.
- Dropped the timer drain; `Stop()` + `Reset()` is the correct Go 1.23+ pattern.
- `SessionManager.Close` snapshots sessions under the lock, then closes them.

## Verification

- `go build ./...`, `go vet`, full `go test ./` and **`go test -race ./`** pass.
- New `TestSession_CloseIsIdempotent` (16 concurrent closes + one more — panics against the old check-then-act) and `TestSession_ExpiryReleasesAttachments` (a session expiring naturally returns its attachment bytes to the global budget — fails against the old goroutine that skipped attachments).

Remaining session concerns (Put holding the write lock across IMAP round trips, the ctx-cancel provider use-after-close race, non-blocking `UpdateDuration`, `%w` auth-logout wiring) are handled in a separate follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)