### PR TITLE
Session concurrency: unlock Put, fix provider use-after-close, wire logout

### DIFF
--- a/server.go
+++ b/server.go
@@ -620,8 +620,8 @@ func (s *Server) handleError(err error, ctx *Context) {
 	if errors.As(err, &authErr) {
 		s.logger.Debugf("Authentication error detected, logging out user")
 		shouldLogout = true
-	} else if strings.Contains(err.Error(), "failed to re-connect to IMAP server") {
-		s.logger.Debugf("IMAP reconnection failed, logging out user")
+	} else if errors.Is(err, ErrMailProviderUnavailable) {
+		s.logger.Debugf("Mail provider connection lost, logging out user")
 		shouldLogout = true
 	}
 

--- a/session.go
+++ b/session.go
@@ -51,6 +51,10 @@ func generateToken() (string, error) {
 var (
 	ErrSessionExpired      = errors.New("session expired")
 	ErrAttachmentCacheSize = errors.New("Attachments on session exceed maximum file size")
+	// ErrMailProviderUnavailable marks errors where the session's mail provider
+	// connection could not be (re-)established. handleError treats it as a signal
+	// to log the user out rather than looping on 500s.
+	ErrMailProviderUnavailable = errors.New("mail provider unavailable")
 )
 
 // AuthError wraps an authentication error.
@@ -111,9 +115,16 @@ func (s *Session) ping() {
 	}
 }
 
-// UpdateDuration dynamically updates the session's timeout duration.
+// UpdateDuration dynamically updates the session's timeout duration. The send is
+// non-blocking: if the session is already closed, or an update is still pending
+// in the single-slot channel, the update is dropped rather than blocking (and
+// permanently leaking) the calling request goroutine.
 func (s *Session) UpdateDuration(d time.Duration) {
-	s.durationUpdate <- d
+	select {
+	case s.durationUpdate <- d:
+	case <-s.closed:
+	default:
+	}
 }
 
 // Username returns the session's username.
@@ -173,7 +184,10 @@ func (s *Session) DoMailWithContext(ctx context.Context, f func(provider.MailPro
 		s.provider, err = s.manager.connectProvider(s.username, s.password)
 		if err != nil {
 			s.Close()
-			return fmt.Errorf("failed to connect to mail provider: %v", err)
+			// Wrap with %w so errors.As can still recover an AuthError (bad
+			// credentials), and join the sentinel so handleError logs the user
+			// out on a dead connection instead of looping on 500s.
+			return fmt.Errorf("failed to connect to mail provider: %w", errors.Join(ErrMailProviderUnavailable, err))
 		}
 		type threadCapable interface {
 			HasThreadCapability() bool
@@ -196,9 +210,13 @@ func (s *Session) DoMailWithContext(ctx context.Context, f func(provider.MailPro
 	var err error
 	select {
 	case <-ctx.Done():
-		s.provider.Close()
+		// The operation goroutine may still be using the provider. Detach it and
+		// close only after f() has returned, otherwise we would close the client
+		// out from under an in-flight command (a use-after-close race). done is
+		// buffered, so f's send never blocks even though we have returned.
+		closeProviderAfter(s.provider, done)
 		s.provider = nil
-		return fmt.Errorf("context cancelled, closed provider: %v", ctx.Err())
+		return fmt.Errorf("context cancelled: %w", ctx.Err())
 	case err = <-done:
 	}
 
@@ -211,7 +229,7 @@ func (s *Session) DoMailWithContext(ctx context.Context, f func(provider.MailPro
 		s.provider, reErr = s.manager.connectProvider(s.username, s.password)
 		if reErr != nil {
 			s.Close()
-			return fmt.Errorf("failed to re-connect to mail provider: %v", reErr)
+			return fmt.Errorf("failed to re-connect to mail provider: %w", errors.Join(ErrMailProviderUnavailable, reErr))
 		}
 
 		done2 := make(chan error, 1)
@@ -226,14 +244,27 @@ func (s *Session) DoMailWithContext(ctx context.Context, f func(provider.MailPro
 
 		select {
 		case <-ctx.Done():
-			s.provider.Close()
+			closeProviderAfter(s.provider, done2)
 			s.provider = nil
-			return fmt.Errorf("context cancelled during retry, closed provider: %v", ctx.Err())
+			return fmt.Errorf("context cancelled during retry: %w", ctx.Err())
 		case err = <-done2:
 		}
 	}
 
 	return err
+}
+
+// closeProviderAfter closes p once the pending operation (whose result lands on
+// done) has finished, so the provider is never closed while a command is still
+// in flight on it. The goroutine exits as soon as done is signalled.
+func closeProviderAfter(p provider.MailProvider, done <-chan error) {
+	if p == nil {
+		return
+	}
+	go func() {
+		<-done
+		p.Close()
+	}()
 }
 
 // smtpMaxAttempts is the number of times DoSMTP tries an operation before
@@ -755,6 +786,37 @@ func (sm *SessionManager) Put(username, password string) (*Session, error) {
 	// and will be closed when the session is closed. Closing it here would leave
 	// the session with a dead connection.
 
+	var cache *Cache
+	if sm.cacheEnabled {
+		cache = NewCache(sm.cacheTTL)
+	} else {
+		// Create a dummy cache with 1 second TTL to effectively disable caching
+		cache = NewCache(1 * time.Second)
+	}
+
+	s := &Session{
+		manager:        sm,
+		closed:         make(chan struct{}),
+		pings:          make(chan struct{}, 5),
+		durationUpdate: make(chan time.Duration, 1),
+		provider:       p,
+		username:       username,
+		password:       password,
+		attachments:    make(map[string]*Attachment),
+		cache:          cache,
+		duration:       sm.sessionDuration, // updated from user settings below
+	}
+	s.lastAccess.Store(time.Now().UnixNano())
+
+	// Read the user's settings (auto-logout duration, 2FA) BEFORE taking the
+	// manager lock: these go through the session's provider as IMAP round trips,
+	// and holding sm.locker across them would serialize every login and block
+	// all other sessions' requests on one user's network latency.
+	s.duration = sm.calculateSessionDuration(s.Store())
+	if enabled, err := CheckWebAuthnEnabled(s.Store()); err == nil && enabled {
+		s.requires2FA = true
+	}
+
 	sm.locker.Lock()
 	defer sm.locker.Unlock()
 
@@ -781,6 +843,7 @@ func (sm *SessionManager) Put(username, password string) (*Session, error) {
 		token, err = generateToken()
 		if err != nil {
 			p.Close() // Clean up provider on error
+			cache.Close()
 			return nil, fmt.Errorf("failed to generate session token: %w", err)
 		}
 
@@ -797,39 +860,11 @@ func (sm *SessionManager) Put(username, password string) (*Session, error) {
 	// If we exhausted all retries, something is seriously wrong
 	if _, exists := sm.sessions[token]; exists {
 		p.Close() // Clean up provider on error
+		cache.Close()
 		return nil, fmt.Errorf("failed to generate unique session token after %d attempts (possible RNG failure or token space exhaustion)", maxTokenRetries)
 	}
 
-	var cache *Cache
-	if sm.cacheEnabled {
-		cache = NewCache(sm.cacheTTL)
-	} else {
-		// Create a dummy cache with 1 second TTL to effectively disable caching
-		cache = NewCache(1 * time.Second)
-	}
-
-	s := &Session{
-		manager:        sm,
-		closed:         make(chan struct{}),
-		pings:          make(chan struct{}, 5),
-		durationUpdate: make(chan time.Duration, 1),
-		provider:       p,
-		username:       username,
-		password:       password,
-		token:          token,
-		attachments:    make(map[string]*Attachment),
-		cache:          cache,
-		duration:       sm.sessionDuration, // Will be updated after reading user settings
-	}
-	s.lastAccess.Store(time.Now().UnixNano())
-
-	// Calculate effective session duration based on user's AutoLogout preference
-	s.duration = sm.calculateSessionDuration(s.Store())
-
-	// Check if 2FA is enabled for this user
-	if enabled, err := CheckWebAuthnEnabled(s.Store()); err == nil && enabled {
-		s.requires2FA = true
-	}
+	s.token = token
 
 	// Track the session
 	sm.sessions[token] = s

--- a/session_test.go
+++ b/session_test.go
@@ -1,6 +1,8 @@
 package alps
 
 import (
+	"context"
+	"errors"
 	"mime/multipart"
 	"sync"
 	"testing"
@@ -11,6 +13,30 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
+
+// TestDoMailWithContext_ConnectFailureIsIdentifiable verifies that a failed
+// (re)connect surfaces an error that handleError can act on: errors.As must
+// still recover the underlying AuthError (so %w wrapping did not hide it), and
+// errors.Is must match ErrMailProviderUnavailable so the user is logged out
+// instead of looping on 500s.
+func TestDoMailWithContext_ConnectFailureIsIdentifiable(t *testing.T) {
+	authCause := errors.New("invalid credentials")
+	connectProvider := func(username, password string) (provider.MailProvider, error) {
+		return nil, AuthError{cause: authCause}
+	}
+	sm := newSessionManager(
+		connectProvider, nil, &NilLogger{},
+		0, false, nil, 30*time.Minute, time.Hour, 0, 0, 0, 0, 0,
+	)
+	s := &Session{manager: sm, closed: make(chan struct{}), username: "u", password: "p"}
+
+	err := s.DoMailWithContext(context.Background(), func(p provider.MailProvider) error { return nil })
+	assert.Error(t, err)
+
+	var authErr AuthError
+	assert.True(t, errors.As(err, &authErr), "AuthError must survive %%w wrapping so errors.As matches")
+	assert.True(t, errors.Is(err, ErrMailProviderUnavailable), "sentinel must be joined so handleError logs out")
+}
 
 // TestSession_CloseIsIdempotent verifies that Close can be called repeatedly and
 // concurrently without panicking on a double close of the signalling channel.


### PR DESCRIPTION
> **Stacked on #21** (`fix/session-lifecycle`). Review/merge #21 first; this PR's diff is only the concurrency/error-wiring changes on top. Its `-race` tests depend on #21's `SessionManager.Close` fix, so it targets that branch as its base.

Four related session-correctness fixes:

### 1. Put held the manager write lock across two IMAP round trips (high)
`Put` read the user's auto-logout duration and 2FA flag via the session's provider (`calculateSessionDuration`, `CheckWebAuthnEnabled`) **while holding `sm.locker`**. Since a pending writer blocks new readers on `sync.RWMutex`, one slow/hung login froze **every** user's requests (all of which take `sm.locker.RLock` via `Get`). Now the session is built and its settings read **before** taking the lock; the lock is held only for limit enforcement, token generation, and map insertion. (Cache is created before the lock, so the token-failure paths close it.)

### 2. Provider closed under an in-flight operation on ctx cancellation (high)
On `ctx.Done()`, `DoMailWithContext` called `s.provider.Close()` while the operation goroutine was still issuing commands on that client — a use-after-close data race (race-detector visible, intermittent panics in go-imap). Now the close is **detached**: a helper waits for the operation to finish (its result lands on a buffered channel) and only then closes the orphaned provider.

### 3. UpdateDuration could hang a request goroutine forever (medium)
The blocking send on a single-slot channel would block permanently if the session's goroutine had exited or the slot was full. Made non-blocking with a `select` that also watches `s.closed`.

### 4. Logout-on-auth-failure was dead code (high)
`handleError` used `errors.As(err, &AuthError)` — but connect errors were wrapped with `%v`, stripping the type — and a fallback that matched `"failed to re-connect to IMAP server"`, a string the code no longer produces. So a mid-session IMAP password change looped the SPA on 500s forever. Connect/reconnect errors are now wrapped with `%w` and joined with a new `ErrMailProviderUnavailable` sentinel; `handleError` logs out via `errors.As`/`errors.Is`.

## Verification

- `go build ./...`, `go vet`, full `go test ./` and `go test -race ./` (5× to shake the flaky path) all pass.
- New `TestDoMailWithContext_ConnectFailureIsIdentifiable` asserts a failed connect satisfies both `errors.As(AuthError)` and `errors.Is(ErrMailProviderUnavailable)` (the wiring `handleError` relies on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)