### PR TITLE
Set cookie Secure from browser-facing scheme (fix missing Secure behind TLS proxy)

### DIFF
--- a/context.go
+++ b/context.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"mime/multipart"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/fernet/fernet-go"
@@ -150,6 +151,26 @@ func (c *Context) IsTLS() bool {
 	return c.Request.TLS != nil
 }
 
+// isEffectiveHTTPS reports whether the browser's connection is HTTPS, accounting
+// for a trusted TLS-terminating reverse proxy that forwards plain HTTP with
+// X-Forwarded-Proto. Cookie Secure flags must reflect the browser-facing scheme,
+// not the (possibly plaintext) hop between the proxy and alps — otherwise the
+// session cookie and the login-token cookie (which carries the fernet-encrypted
+// password) would be set without Secure in the recommended proxy deployment.
+// Forwarded headers are only honored when the immediate peer is a configured
+// trusted proxy, mirroring the CSRF middleware.
+func (c *Context) isEffectiveHTTPS() bool {
+	if c.IsTLS() {
+		return true
+	}
+	if isRequestFromTrustedProxy(c) {
+		if proto := firstForwardedValue(c.Request.Header.Get("X-Forwarded-Proto")); proto != "" {
+			return strings.EqualFold(proto, "https")
+		}
+	}
+	return false
+}
+
 // Logger returns the server logger.
 func (c *Context) Logger() Logger {
 	return c.Server.logger
@@ -169,14 +190,14 @@ func (c *Context) SetSessionWithExpiry(s *Session, persistent bool) {
 		Path:     "/", // Important: cookie must be valid for all paths
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,
-		Secure:   c.IsTLS(),
+		Secure:   c.isEffectiveHTTPS(),
 	}
 	frontendCookie := http.Cookie{
 		Name:     "alps_logged_in",
 		Path:     "/",
 		HttpOnly: false,
 		SameSite: http.SameSiteStrictMode,
-		Secure:   c.IsTLS(),
+		Secure:   c.isEffectiveHTTPS(),
 	}
 
 	if s != nil {
@@ -210,7 +231,7 @@ func (c *Context) SetLoginToken(username, password string, verified2FA bool, per
 		Name:     loginTokenCookieName,
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,
-		Secure:   c.IsTLS(),
+		Secure:   c.isEffectiveHTTPS(),
 		Path:     "/",
 	}
 	frontendCookie := http.Cookie{
@@ -218,7 +239,7 @@ func (c *Context) SetLoginToken(username, password string, verified2FA bool, per
 		Path:     "/",
 		HttpOnly: false,
 		SameSite: http.SameSiteStrictMode,
-		Secure:   c.IsTLS(),
+		Secure:   c.isEffectiveHTTPS(),
 	}
 
 	if persistent {

--- a/context_test.go
+++ b/context_test.go
@@ -1,8 +1,10 @@
 package alps
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,6 +13,54 @@ import (
 	"github.com/fernet/fernet-go"
 	"github.com/stretchr/testify/assert"
 )
+
+// TestContext_CookieSecureReflectsForwardedProto verifies that the cookie Secure
+// flag reflects the browser-facing scheme: HTTPS directly, or HTTP forwarded as
+// https by a trusted proxy — but never a spoofed X-Forwarded-Proto from an
+// untrusted peer.
+func TestContext_CookieSecureReflectsForwardedProto(t *testing.T) {
+	_, privateNet, _ := net.ParseCIDR("10.0.0.0/8")
+	trustedServer := &Server{Options: &Options{TrustedProxies: []*net.IPNet{privateNet}}}
+	noProxyServer := &Server{Options: &Options{}}
+
+	newCtx := func(server *Server, isTLS bool, remoteAddr, xfp string) *Context {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.RemoteAddr = remoteAddr
+		if isTLS {
+			req.TLS = &tls.ConnectionState{}
+		}
+		if xfp != "" {
+			req.Header.Set("X-Forwarded-Proto", xfp)
+		}
+		return NewContext(httptest.NewRecorder(), req, server)
+	}
+
+	cases := []struct {
+		name       string
+		ctx        *Context
+		wantSecure bool
+	}{
+		{"direct TLS", newCtx(noProxyServer, true, "1.2.3.4:9", ""), true},
+		{"plain HTTP, no proxy", newCtx(noProxyServer, false, "1.2.3.4:9", ""), false},
+		{"trusted proxy forwards https", newCtx(trustedServer, false, "10.0.0.5:9", "https"), true},
+		{"trusted proxy forwards http", newCtx(trustedServer, false, "10.0.0.5:9", "http"), false},
+		{"untrusted peer spoofs https", newCtx(trustedServer, false, "203.0.113.9:9", "https"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.wantSecure, tc.ctx.isEffectiveHTTPS())
+		})
+	}
+
+	// End-to-end: the session cookie must carry Secure behind a trusted https proxy.
+	c := newCtx(trustedServer, false, "10.0.0.5:9", "https")
+	c.SetSession(&Session{token: "tok"})
+	for _, ck := range c.Response.(*httptest.ResponseRecorder).Result().Cookies() {
+		if ck.Name == cookieName {
+			assert.True(t, ck.Secure, "session cookie must be Secure behind an https-terminating trusted proxy")
+		}
+	}
+}
 
 func TestContextSetGet(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)


### PR DESCRIPTION
## Problem

The session cookie (`alps_session`) and the login-token cookie (`alps_login_token`, which stores the **fernet-encrypted password**) set their `Secure` flag from `c.IsTLS()` — i.e. `Request.TLS != nil`.

In the recommended deployment behind a TLS-terminating reverse proxy, the proxy speaks HTTPS to the browser but forwards **plain HTTP** to alps, so `Request.TLS` is nil and both cookies were set **without `Secure`**. A browser could then be induced to send them over a plain-HTTP request to the same host, leaking the session token and the encrypted-password token.

## Fix

Add `isEffectiveHTTPS()`, which reports HTTPS when the request is TLS **or** when a configured trusted proxy forwarded `X-Forwarded-Proto: https` — reusing the same `isRequestFromTrustedProxy` / `firstForwardedValue` helpers the CSRF middleware already uses. A spoofed `X-Forwarded-Proto` from an untrusted peer is ignored. All four cookie `Secure` fields now use it.

## Verification

- `go build ./...`, `go vet`, full `go test ./` pass.
- New `TestContext_CookieSecureReflectsForwardedProto` covers: direct TLS → Secure; plain HTTP no proxy → not Secure; trusted proxy `https`/`http` → Secure/not; untrusted peer spoofing `https` → not Secure; plus an end-to-end check that the session cookie carries `Secure` behind an https-terminating trusted proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)