### PR TITLE
Password change: verify the current password against the session

### DIFF
--- a/plugins/password/routes.go
+++ b/plugins/password/routes.go
@@ -2,6 +2,7 @@ package password
 
 import (
 	"bytes"
+	"crypto/subtle"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -52,6 +53,16 @@ func handlePasswordChange(ctx *alps.Context) error {
 
 	if req.OldPassword == "" || req.Password == "" {
 		return ctx.JSON(http.StatusBadRequest, map[string]string{"error": "Old and new password are required"})
+	}
+
+	// Verify the supplied current password against the authenticated session
+	// before contacting the backend. Without this, a hijacked or CSRF'd (but
+	// authenticated) session could set a new password without proving knowledge
+	// of the current one — the backend only enforces old_password if the
+	// deployment's payload_mapping happens to forward it. Constant-time compare
+	// to avoid leaking the password via response timing.
+	if subtle.ConstantTimeCompare([]byte(req.OldPassword), []byte(ctx.Session.Password())) != 1 {
+		return ctx.JSON(http.StatusForbidden, map[string]string{"error": "Current password is incorrect"})
 	}
 
 	username := ctx.Session.Username()


### PR DESCRIPTION
## Problem

`handlePasswordChange` required `old_password` to be non-empty but **never compared it to the authenticated session's actual password**. It only forwarded the value to the configured backend endpoint — and only if the deployment's `payload_mapping` happened to map `old_password`. If that mapping omits it (or the backend doesn't enforce it), a hijacked or CSRF'd but authenticated session could set a new password without proving knowledge of the current one, discarding the "re-enter current password" defense-in-depth guarantee.

## Fix

Before contacting the backend, compare `old_password` to `ctx.Session.Password()` using a constant-time comparison (`crypto/subtle`, to avoid a timing oracle) and reject with 403 on mismatch.

## Verification

- `go build ./...` and `go vet ./plugins/password/` pass.
- Note: the password plugin has no test harness — the session's password field is unexported, so a `password`-package test cannot construct a `Session` with a known password. The change is a small, self-contained guard placed before any backend I/O (the wrong-password path returns 403 without external calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)