### PR TITLE
CalDAV: XML-escape displayname and fix absolute-href URL double-prefix

### DIFF
--- a/plugins/caldav/routes.go
+++ b/plugins/caldav/routes.go
@@ -1,6 +1,8 @@
 package alpscaldav
 
 import (
+	"bytes"
+	"encoding/xml"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -13,6 +15,30 @@ import (
 	"github.com/google/uuid"
 	"github.com/migadu/alps"
 )
+
+// resolveDAVPath returns the URL path to use for a DAV object href. DAV servers
+// return absolute hrefs (a full URL, or a path rooted at the server such as
+// "/dav/calendars/..."), which already include any endpoint base path and must
+// be used as-is. Only a relative href is joined onto the configured endpoint's
+// base path. path.Join-ing an absolute href onto the base double-prefixes it
+// (e.g. "/dav/dav/calendars/...") and 404s on any endpoint not mounted at "/".
+func resolveDAVPath(base *url.URL, href string) string {
+	if u, err := url.Parse(href); err == nil && u.IsAbs() {
+		return u.Path
+	}
+	if strings.HasPrefix(href, "/") {
+		return href
+	}
+	return path.Join(base.Path, href)
+}
+
+// xmlEscape returns s escaped for inclusion in XML character data.
+func xmlEscape(s string) string {
+	var b bytes.Buffer
+	// xml.EscapeText only fails if the writer fails; a bytes.Buffer never does.
+	_ = xml.EscapeText(&b, []byte(s))
+	return b.String()
+}
 
 type CalendarData struct {
 	Name        string `json:"name"`
@@ -127,7 +153,7 @@ func registerRoutes(p *plugin) {
 		newPath := path.Join(homeSet, newID) + "/"
 
 		targetURL := *p.url
-		targetURL.Path = path.Join(targetURL.Path, newPath)
+		targetURL.Path = resolveDAVPath(p.url, newPath)
 		if !strings.HasSuffix(targetURL.Path, "/") {
 			targetURL.Path += "/"
 		}
@@ -139,7 +165,7 @@ func registerRoutes(p *plugin) {
       <D:displayname>%s</D:displayname>
     </D:prop>
   </D:set>
-</C:mkcalendar>`, req.Name)
+</C:mkcalendar>`, xmlEscape(req.Name))
 
 		rt := authRoundTripper{
 			server:  http.DefaultTransport,
@@ -203,7 +229,7 @@ func registerRoutes(p *plugin) {
 		}
 
 		targetURL := *p.url
-		targetURL.Path = path.Join(targetURL.Path, calPath)
+		targetURL.Path = resolveDAVPath(p.url, calPath)
 		if !strings.HasSuffix(targetURL.Path, "/") {
 			targetURL.Path += "/"
 		}
@@ -215,7 +241,7 @@ func registerRoutes(p *plugin) {
       <D:displayname>%s</D:displayname>
     </D:prop>
   </D:set>
-</D:propertyupdate>`, req.Name)
+</D:propertyupdate>`, xmlEscape(req.Name))
 
 		rt := authRoundTripper{
 			server:  http.DefaultTransport,

--- a/plugins/caldav/routes_test.go
+++ b/plugins/caldav/routes_test.go
@@ -1,0 +1,43 @@
+package alpscaldav
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestResolveDAVPath(t *testing.T) {
+	cases := []struct {
+		name     string
+		basePath string
+		href     string
+		want     string
+	}{
+		{"root base, absolute href", "/", "/dav/calendars/u/c/", "/dav/calendars/u/c/"},
+		{"non-root base does not double-prefix", "/dav/", "/dav/calendars/u/c/", "/dav/calendars/u/c/"},
+		// path.Join cleans the trailing slash; the handler re-adds it afterward.
+		{"relative href joins onto base", "/dav/", "sub/c/", "/dav/sub/c"},
+		{"full URL href uses its path", "/dav/", "https://dav.example.com/dav/calendars/u/c/", "/dav/calendars/u/c/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			base := &url.URL{Scheme: "https", Host: "dav.example.com", Path: tc.basePath}
+			if got := resolveDAVPath(base, tc.href); got != tc.want {
+				t.Errorf("resolveDAVPath(%q, %q) = %q, want %q", tc.basePath, tc.href, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestXMLEscape(t *testing.T) {
+	cases := map[string]string{
+		"Me & You":                 "Me &amp; You",
+		"<script>alert(1)</script>": "&lt;script&gt;alert(1)&lt;/script&gt;",
+		"plain":                    "plain",
+		`a"b`:                      "a&#34;b",
+	}
+	for in, want := range cases {
+		if got := xmlEscape(in); got != want {
+			t.Errorf("xmlEscape(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Problems

The hand-rolled CalDAV MKCALENDAR (create) and PROPPATCH (rename) requests had two bugs:

**1. XML injection / breakage.** The user-supplied calendar name was interpolated into the request body with `fmt.Sprintf` and **no XML escaping**:
```go
`... <D:displayname>%s</D:displayname> ...`, req.Name
```
A name containing `&`, `<`, or `>` (e.g. `Me & You`) produces malformed XML the DAV server rejects, so those names silently fail — and a crafted name can inject arbitrary XML elements into the propertyupdate/mkcalendar request against the user's own account.

**2. Absolute-href URL double-prefix.** The target URL was built as `path.Join(p.url.Path, <objectPath>)`, but `objectPath` / home-set / calendar paths are **absolute hrefs** returned by the server. Joining an absolute href onto a non-root endpoint base double-prefixes it (`/dav/dav/calendars/...`) and 404s. Only deployments whose endpoint is mounted at `/` happened to work. (The delete/event routes use go-webdav library methods and were unaffected — this was an internal inconsistency.)

## Fix

- `xmlEscape()` (via `xml.EscapeText`) wraps `req.Name` in both payloads.
- `resolveDAVPath()` uses absolute hrefs (and full URLs) **as-is** and only `path.Join`s relative ones onto the base. For a `/`-mounted endpoint the result is identical to before, so currently-working deployments are unaffected; non-root endpoints are fixed.

## Verification

- `go build ./...`, `go vet`, and new `go test ./plugins/caldav/` pass.
- New tests: `TestResolveDAVPath` (root base, non-root base no-double-prefix, relative join, full-URL href) and `TestXMLEscape` (`&`, `<`/`>`, quotes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)