### PR TITLE
Cluster: fix advertise address, retry joins, require a secret key

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"sort"
 	"sync"
 	"time"
@@ -40,12 +41,13 @@ type Cluster struct {
 
 // Config holds configuration for creating a cluster.
 type Config struct {
-	NodeName  string   // This node's name (defaults to hostname, determines leader order)
-	BindAddr  string   // Address to bind to (e.g., "0.0.0.0")
-	BindPort  int      // Port to bind to for memberlist (default: 7946)
-	Peers     []string // Other cluster nodes to connect to (e.g., ["node1:7946", "node2:7946"])
-	SecretKey []byte   // 32-byte encryption key for gossip protocol (AES-256)
-	Logger    *slog.Logger
+	NodeName      string   // This node's name (defaults to hostname, determines leader order)
+	BindAddr      string   // Address to bind to (e.g., "0.0.0.0")
+	BindPort      int      // Port to bind to for memberlist (default: 7946)
+	Peers         []string // Other cluster nodes to connect to (e.g., ["node1:7946", "node2:7946"])
+	SecretKey     []byte   // 32-byte encryption key for gossip protocol (AES-256)
+	AllowInsecure bool     // Permit running without a SecretKey (unencrypted, unauthenticated gossip)
+	Logger        *slog.Logger
 }
 
 // NewCluster creates a new cluster instance with memberlist and leader election.
@@ -72,16 +74,23 @@ func NewCluster(cfg Config) (*Cluster, error) {
 		mlConfig.BindPort = cfg.BindPort
 	}
 
-	// Set advertise address - use bind address as advertise address
-	// This allows memberlist to work with public IPs or when bind is 0.0.0.0
-	if cfg.BindAddr != "" {
+	// Advertise a concrete address to peers only when we bind to a specific IP.
+	// Binding to 0.0.0.0 / :: (or empty) means "all interfaces"; advertising that
+	// literally makes peers try to reach us at an unspecified address and mark us
+	// suspect/dead, so membership never forms. Leaving AdvertiseAddr empty lets
+	// memberlist auto-detect a routable private IP. A hostname (ParseIP == nil)
+	// is likewise left to auto-detection since AdvertiseAddr expects an IP.
+	if ip := net.ParseIP(cfg.BindAddr); ip != nil && !ip.IsUnspecified() {
 		mlConfig.AdvertiseAddr = cfg.BindAddr
 	}
 	if cfg.BindPort > 0 {
 		mlConfig.AdvertisePort = cfg.BindPort
 	}
 
-	// Enable gossip encryption if secret key is provided
+	// Enable gossip encryption if secret key is provided. Both cluster consumers
+	// (rate-limit events, leader election for cert issuance) are security
+	// sensitive, so refuse to run unencrypted/unauthenticated unless the operator
+	// explicitly opted in.
 	if len(cfg.SecretKey) > 0 {
 		if len(cfg.SecretKey) != 32 {
 			return nil, fmt.Errorf("secret key must be exactly 32 bytes, got %d", len(cfg.SecretKey))
@@ -90,8 +99,10 @@ func NewCluster(cfg Config) (*Cluster, error) {
 		mlConfig.GossipVerifyIncoming = true
 		mlConfig.GossipVerifyOutgoing = true
 		cfg.Logger.Info("gossip encryption enabled (AES-256)")
+	} else if !cfg.AllowInsecure {
+		return nil, fmt.Errorf("cluster secret_key is required: without it gossip is unencrypted and unauthenticated, allowing forged rate-limit events (arbitrary account lockout / lockout clearing) and leader hijacking; set cluster.secret_key, or set cluster.allow_insecure = true to run without encryption on a fully trusted network")
 	} else {
-		cfg.Logger.Warn("gossip encryption DISABLED - cluster communication is INSECURE")
+		cfg.Logger.Warn("gossip encryption DISABLED (allow_insecure set) - cluster communication is INSECURE")
 	}
 
 	// Set event delegate for membership changes (triggers leader recalculation)
@@ -117,12 +128,15 @@ func NewCluster(cfg Config) (*Cluster, error) {
 	}
 	cluster.leaderMtx.Unlock()
 
-	// Join peers if provided
+	// Join peers if provided. This is best-effort at startup (peers may not be up
+	// yet); rejoinLoop below periodically retries so a failed initial join or a
+	// healed network partition does not leave this node as a permanent singleton
+	// (which would make it its own leader and independently request LE certs).
 	if len(cfg.Peers) > 0 {
-		_, err := ml.Join(cfg.Peers)
-		if err != nil {
+		if _, err := ml.Join(cfg.Peers); err != nil {
 			cfg.Logger.Warn("failed to join some peers (may be first node)", "error", err)
 		}
+		go cluster.rejoinLoop(cfg.Peers)
 	}
 
 	// Initialize leader election
@@ -158,6 +172,35 @@ func NewCluster(cfg Config) (*Cluster, error) {
 		"is_leader", cluster.IsLeader())
 
 	return cluster, nil
+}
+
+// rejoinLoop periodically re-attempts to join the configured peers whenever this
+// node appears isolated (only itself in the member list). memberlist never merges
+// two disjoint clusters on its own — someone must call Join again — so without
+// this a failed startup join or a partition heals into permanent split-brain,
+// with every partition electing its own leader.
+func (c *Cluster) rejoinLoop(peers []string) {
+	defer func() {
+		if r := recover(); r != nil {
+			c.logger.Error("panic in cluster rejoin goroutine", "panic", r)
+		}
+	}()
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.done:
+			return
+		case <-ticker.C:
+			if c.ml != nil && c.ml.NumMembers() <= 1 {
+				if _, err := c.ml.Join(peers); err != nil {
+					c.logger.Debug("cluster rejoin attempt failed", "error", err)
+				} else {
+					c.logger.Info("cluster rejoined peers", "members", c.ml.NumMembers())
+				}
+			}
+		}
+	}
 }
 
 // IsLeader returns true if this node is the cluster leader.

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -11,12 +11,40 @@ func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
+// TestNewCluster_RejectsKeylessWithoutOptIn verifies that a cluster refuses to
+// start with unencrypted gossip unless the operator explicitly opts in, and that
+// AllowInsecure permits it.
+func TestNewCluster_RejectsKeylessWithoutOptIn(t *testing.T) {
+	_, err := NewCluster(Config{
+		NodeName: "insecure-default",
+		BindAddr: "127.0.0.1",
+		BindPort: 17960,
+		Logger:   testLogger(),
+	})
+	if err == nil {
+		t.Fatal("expected NewCluster to reject keyless mode without AllowInsecure")
+	}
+
+	c, err := NewCluster(Config{
+		NodeName:      "insecure-optin",
+		BindAddr:      "127.0.0.1",
+		BindPort:      17961,
+		AllowInsecure: true,
+		Logger:        testLogger(),
+	})
+	if err != nil {
+		t.Fatalf("AllowInsecure should permit keyless mode: %v", err)
+	}
+	c.Shutdown()
+}
+
 func TestLeaderElection_SingleNode(t *testing.T) {
 	c, err := NewCluster(Config{
-		NodeName: "alpha",
-		BindAddr: "127.0.0.1",
-		BindPort: 17946,
-		Logger:   testLogger(),
+		NodeName:      "alpha",
+		BindAddr:      "127.0.0.1",
+		BindPort:      17946,
+		AllowInsecure: true,
+		Logger:        testLogger(),
 	})
 	if err != nil {
 		t.Fatalf("failed to create cluster: %v", err)
@@ -38,10 +66,11 @@ func TestLeaderElection_SingleNode(t *testing.T) {
 func TestLeaderElection_TwoNodes(t *testing.T) {
 	// Node "alpha" should become leader (lexicographically smallest)
 	c1, err := NewCluster(Config{
-		NodeName: "alpha",
-		BindAddr: "127.0.0.1",
-		BindPort: 17947,
-		Logger:   testLogger(),
+		NodeName:      "alpha",
+		BindAddr:      "127.0.0.1",
+		BindPort:      17947,
+		AllowInsecure: true,
+		Logger:        testLogger(),
 	})
 	if err != nil {
 		t.Fatalf("failed to create node1: %v", err)
@@ -49,11 +78,12 @@ func TestLeaderElection_TwoNodes(t *testing.T) {
 	defer c1.Shutdown()
 
 	c2, err := NewCluster(Config{
-		NodeName: "beta",
-		BindAddr: "127.0.0.1",
-		BindPort: 17948,
-		Peers:    []string{"127.0.0.1:17947"},
-		Logger:   testLogger(),
+		NodeName:      "beta",
+		BindAddr:      "127.0.0.1",
+		BindPort:      17948,
+		Peers:         []string{"127.0.0.1:17947"},
+		AllowInsecure: true,
+		Logger:        testLogger(),
 	})
 	if err != nil {
 		t.Fatalf("failed to create node2: %v", err)
@@ -87,21 +117,23 @@ func TestLeaderElection_TwoNodes(t *testing.T) {
 
 func TestLeaderElection_Failover(t *testing.T) {
 	c1, err := NewCluster(Config{
-		NodeName: "alpha",
-		BindAddr: "127.0.0.1",
-		BindPort: 17949,
-		Logger:   testLogger(),
+		NodeName:      "alpha",
+		BindAddr:      "127.0.0.1",
+		BindPort:      17949,
+		AllowInsecure: true,
+		Logger:        testLogger(),
 	})
 	if err != nil {
 		t.Fatalf("failed to create node1: %v", err)
 	}
 
 	c2, err := NewCluster(Config{
-		NodeName: "beta",
-		BindAddr: "127.0.0.1",
-		BindPort: 17950,
-		Peers:    []string{"127.0.0.1:17949"},
-		Logger:   testLogger(),
+		NodeName:      "beta",
+		BindAddr:      "127.0.0.1",
+		BindPort:      17950,
+		Peers:         []string{"127.0.0.1:17949"},
+		AllowInsecure: true,
+		Logger:        testLogger(),
 	})
 	if err != nil {
 		t.Fatalf("failed to create node2: %v", err)
@@ -129,10 +161,11 @@ func TestLeaderElection_Failover(t *testing.T) {
 
 func TestHealthStatus(t *testing.T) {
 	c, err := NewCluster(Config{
-		NodeName: "health-test",
-		BindAddr: "127.0.0.1",
-		BindPort: 17951,
-		Logger:   testLogger(),
+		NodeName:      "health-test",
+		BindAddr:      "127.0.0.1",
+		BindPort:      17951,
+		AllowInsecure: true,
+		Logger:        testLogger(),
 	})
 	if err != nil {
 		t.Fatalf("failed to create cluster: %v", err)

--- a/cmd/alps/config.go
+++ b/cmd/alps/config.go
@@ -26,12 +26,13 @@ type Config struct {
 }
 
 type ClusterConfig struct {
-	Enabled   bool     `toml:"enabled"`
-	NodeID    string   `toml:"node_id"`
-	Bind      string   `toml:"bind"`       // e.g., "0.0.0.0" or "0.0.0.0:7946"
-	Port      int      `toml:"port"`       // default: 7946
-	SecretKey string   `toml:"secret_key"` // base64 encoded 32-byte key
-	Peers     []string `toml:"peers"`      // List of peer addresses
+	Enabled       bool     `toml:"enabled"`
+	NodeID        string   `toml:"node_id"`
+	Bind          string   `toml:"bind"`           // e.g., "0.0.0.0" or "0.0.0.0:7946"
+	Port          int      `toml:"port"`           // default: 7946
+	SecretKey     string   `toml:"secret_key"`     // base64 encoded 32-byte key
+	AllowInsecure bool     `toml:"allow_insecure"` // permit running without secret_key (unencrypted gossip)
+	Peers         []string `toml:"peers"`          // List of peer addresses
 }
 
 // GetBindAddr returns just the IP address part of Bind, or 0.0.0.0 if empty.

--- a/cmd/alps/main.go
+++ b/cmd/alps/main.go
@@ -138,12 +138,13 @@ func main() {
 		}
 
 		clusterMgr, err = cluster.NewCluster(cluster.Config{
-			NodeName:  nodeID,
-			BindAddr:  config.Cluster.GetBindAddr(),
-			BindPort:  config.Cluster.GetBindPort(),
-			Peers:     config.Cluster.Peers,
-			SecretKey: secretKey,
-			Logger:    slog.Default(),
+			NodeName:      nodeID,
+			BindAddr:      config.Cluster.GetBindAddr(),
+			BindPort:      config.Cluster.GetBindPort(),
+			Peers:         config.Cluster.Peers,
+			SecretKey:     secretKey,
+			AllowInsecure: config.Cluster.AllowInsecure,
+			Logger:        slog.Default(),
 		})
 		if err != nil {
 			logger.Errorf("failed to initialize cluster (falling back to single-node mode): %v", err)

--- a/config.example.toml
+++ b/config.example.toml
@@ -318,7 +318,12 @@ enabled = false
 # bind = "0.0.0.0"                              # Can be "IP:port" or just "IP" (default: 0.0.0.0)
 # port = 7946                                    # Gossip port, used if not specified in bind (default: 7946)
 # secret_key = "base64-encoded-32-byte-key"    # Generate: openssl rand -base64 32
-# peers = ["node2:7946", "node3:7946"]
+# A secret_key is REQUIRED: without it, gossip is unencrypted and unauthenticated,
+# letting anyone with reach of the gossip port forge rate-limit events (lock out or
+# unlock arbitrary accounts) and hijack leader election. To run without encryption on
+# a fully trusted/private network, you must explicitly opt in:
+# allow_insecure = false                        # Set true to permit keyless (insecure) gossip
+# peers = ["node2:7946", "node3:7946"]           # List ALL internal peers so right-to-left XFF and rejoin work
 
 
 [provider]


### PR DESCRIPTION
Three cluster-membership correctness/security fixes.

### 1. Advertise `0.0.0.0` breaks membership (high)
`NewCluster` set `mlConfig.AdvertiseAddr = cfg.BindAddr` unconditionally. With the default bind (`0.0.0.0`), every node gossiped its address as `0.0.0.0:7946`; peers probing that address connect to their own listener, get a "ping for wrong node" response, and mark the peer suspect/dead — so membership flaps or never forms. Now an explicit advertise address is set **only** for a concrete, non-unspecified IP; for `0.0.0.0`/`::`/empty/hostname it's left empty so memberlist auto-detects a routable private IP.

### 2. One-shot Join → permanent split-brain (high)
`ml.Join(peers)` was attempted exactly once at startup; on failure the node became a healthy **singleton** — its own leader, independently requesting Let's Encrypt certs. memberlist never merges two disjoint clusters on its own. Added `rejoinLoop`, which re-attempts `Join` every 30s whenever the node is isolated (`NumMembers <= 1`), healing a failed startup join or a network partition.

### 3. Keyless gossip is insecure by default (medium)
Without a `secret_key`, gossip is unencrypted and unauthenticated: anyone reaching the gossip port can forge `RateLimitEvent`s (lock out or clear arbitrary accounts, defeating distributed brute-force protection) or join with a name like `"0"` to hijack leader election. `NewCluster` now **refuses to start** a keyless cluster unless `cluster.allow_insecure = true` is set explicitly.

## Verification

- `go build ./...`, `go vet`, and `go test ./cluster/` pass.
- Existing cluster tests updated to set `AllowInsecure: true` (they run on a trusted loopback network). New `TestNewCluster_RejectsKeylessWithoutOptIn` asserts the reject/opt-in behavior. Example config documents the new option.

**Operator note:** an existing keyless cluster must add `allow_insecure = true` (or, preferably, set a `secret_key`) — otherwise cluster init errors and the node falls back to single-node mode. For correct right-to-left XFF resolution and rejoin, `peers` should list **all** internal nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)