### PR TITLE
TLS cache: compare cert expiry on sync, return ErrCacheMiss on S3 errors

### DIFF
--- a/tlsmanager/storage/fallback_cache.go
+++ b/tlsmanager/storage/fallback_cache.go
@@ -3,6 +3,8 @@ package storage
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"log/slog"
 	"os"
@@ -13,6 +15,33 @@ import (
 
 	"golang.org/x/crypto/acme/autocert"
 )
+
+// certNotAfter parses a PEM cert+key bundle (as stored by autocert) and returns
+// the leaf certificate's expiry. ok is false when the data holds no parseable
+// certificate (e.g. account keys or challenge tokens).
+func certNotAfter(pemData []byte) (t time.Time, ok bool) {
+	rest := pemData
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			return time.Time{}, false
+		}
+		if block.Type == "CERTIFICATE" {
+			cert, err := x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				return time.Time{}, false
+			}
+			return cert.NotAfter, true
+		}
+	}
+}
+
+// isChallengeToken reports whether an autocert cache key is an ephemeral ACME
+// challenge token (http-01 or tls-alpn-01) rather than a certificate.
+func isChallengeToken(name string) bool {
+	return strings.HasSuffix(name, "+http-01") || strings.HasSuffix(name, "+token")
+}
 
 // FallbackCache implements a two-tier cache system:
 // - Primary: S3 (source of truth, shared across cluster)
@@ -180,10 +209,14 @@ func (f *FallbackCache) Get(ctx context.Context, key string) ([]byte, error) {
 		return nil, autocert.ErrCacheMiss
 	}
 
-	// S3 error (timeout or other error) - mark as unavailable
-	f.logger.Warn("FallbackCache: S3 Get failed (marking S3 unavailable)", "name", key, "error", err)
+	// S3 error (timeout or other error) - mark as unavailable and report a cache
+	// miss. autocert treats any non-ErrCacheMiss error from Get as fatal for the
+	// handshake (it does NOT fall through to certificate issuance), so returning
+	// the raw transport error would abort handshakes for uncached domains that
+	// could otherwise have triggered issuance. This matches the breaker-open path.
+	f.logger.Warn("FallbackCache: S3 Get failed (treating as cache miss)", "name", key, "error", err)
 	f.markS3Unavailable()
-	return nil, err
+	return nil, autocert.ErrCacheMiss
 }
 
 // Put stores a certificate, trying S3 first (source of truth), then falling back to local cache.
@@ -346,8 +379,25 @@ func (f *FallbackCache) SyncAllToS3(ctx context.Context) error {
 				skipped++
 				continue
 			}
-			// Different certificate - need to sync
-			f.logger.Debug("certificate differs in S3, syncing", "name", name)
+			// Contents differ. For certificate bundles, do NOT blindly overwrite
+			// S3 with the local copy: a byte difference does not tell us which is
+			// newer, and pushing a stale local cert over a freshly-renewed S3 cert
+			// (e.g. this node restarted with a pre-renewal cert on disk) resurrects
+			// the old cert cluster-wide. Compare expiry: if S3 is newer, adopt it
+			// locally (so this node stops serving the stale cert) and leave S3 alone.
+			if localExp, ok := certNotAfter(data); ok {
+				if s3Exp, ok2 := certNotAfter(s3Data); ok2 && s3Exp.After(localExp) {
+					f.logger.Info("S3 certificate is newer than local — refreshing local, not overwriting S3",
+						"name", name, "local_expiry", localExp, "s3_expiry", s3Exp)
+					if putErr := f.fallback.Put(ctx, name, s3Data); putErr != nil {
+						f.logger.Warn("failed to refresh local certificate from S3", "name", name, "error", putErr)
+					}
+					skipped++
+					continue
+				}
+			}
+			// Local is newer (or not a comparable certificate) - sync it up.
+			f.logger.Debug("certificate differs in S3, syncing local up", "name", name)
 		} else if err != autocert.ErrCacheMiss {
 			// Transient S3 error (timeout, network, etc.) - skip this cert.
 			// Do NOT re-upload: we can't confirm the cert is missing vs S3 being unreachable.
@@ -360,8 +410,9 @@ func (f *FallbackCache) SyncAllToS3(ctx context.Context) error {
 
 		// If this is an ephemeral ACME challenge token that is missing in S3, it was
 		// likely completed and deleted by the cluster leader. Instead of resurrecting
-		// it in S3, clean up our local orphaned copy.
-		if err == autocert.ErrCacheMiss && strings.HasSuffix(name, "+token") {
+		// it in S3, clean up our local orphaned copy. This must cover http-01 tokens
+		// (<token>+http-01), the challenge type used here, not just tls-alpn (+token).
+		if err == autocert.ErrCacheMiss && isChallengeToken(name) {
 			f.logger.Info("cleaning up orphaned challenge token from local cache", "name", name)
 			if delErr := f.fallback.Delete(ctx, name); delErr != nil {
 				f.logger.Warn("failed to delete orphaned token from local cache", "name", name, "error", delErr)

--- a/tlsmanager/storage/fallback_cache_test.go
+++ b/tlsmanager/storage/fallback_cache_test.go
@@ -1,0 +1,158 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"io"
+	"log/slog"
+	"math/big"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/acme/autocert"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func makeCertPEM(t *testing.T, notAfter time.Time) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "example.com"},
+		NotBefore:    notAfter.Add(-24 * time.Hour),
+		NotAfter:     notAfter,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return buf.Bytes()
+}
+
+func newTestFallbackCache(t *testing.T) (*FallbackCache, *MockS3Client) {
+	t.Helper()
+	mock := NewMockS3Client()
+	s3 := &S3Cache{S3Client: mock, Bucket: "b", Prefix: "p/", Logger: discardLogger()}
+	fc := NewFallbackCache(t.TempDir(), s3, discardLogger())
+	return fc, mock
+}
+
+// TestSyncAllToS3_DoesNotOverwriteNewerS3Cert verifies stale-resurrection is
+// prevented: a stale local cert must not overwrite a fresher one in S3, and the
+// node adopts the fresher S3 cert locally.
+func TestSyncAllToS3_DoesNotOverwriteNewerS3Cert(t *testing.T) {
+	fc, _ := newTestFallbackCache(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	oldCert := makeCertPEM(t, now.Add(10*24*time.Hour))
+	newCert := makeCertPEM(t, now.Add(80*24*time.Hour))
+
+	if err := fc.fallback.Put(ctx, "example.com", oldCert); err != nil {
+		t.Fatal(err)
+	}
+	if err := fc.primary.Put(ctx, "example.com", newCert); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fc.SyncAllToS3(ctx); err != nil {
+		t.Fatalf("SyncAllToS3: %v", err)
+	}
+
+	s3Got, _ := fc.primary.Get(ctx, "example.com")
+	if !bytes.Equal(s3Got, newCert) {
+		t.Error("S3 cert was overwritten by the older local cert (stale resurrection)")
+	}
+	localGot, _ := fc.fallback.Get(ctx, "example.com")
+	if !bytes.Equal(localGot, newCert) {
+		t.Error("local cert should have been refreshed from the newer S3 cert")
+	}
+}
+
+// TestSyncAllToS3_PushesNewerLocalCert verifies the normal direction still works:
+// a newer local cert is synced up to S3.
+func TestSyncAllToS3_PushesNewerLocalCert(t *testing.T) {
+	fc, _ := newTestFallbackCache(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	oldCert := makeCertPEM(t, now.Add(10*24*time.Hour))
+	newCert := makeCertPEM(t, now.Add(80*24*time.Hour))
+
+	if err := fc.fallback.Put(ctx, "example.com", newCert); err != nil {
+		t.Fatal(err)
+	}
+	if err := fc.primary.Put(ctx, "example.com", oldCert); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fc.SyncAllToS3(ctx); err != nil {
+		t.Fatalf("SyncAllToS3: %v", err)
+	}
+
+	s3Got, _ := fc.primary.Get(ctx, "example.com")
+	if !bytes.Equal(s3Got, newCert) {
+		t.Error("newer local cert should have been synced up to S3")
+	}
+}
+
+// TestSyncAllToS3_CleansOrphanedHTTP01Token verifies http-01 challenge tokens
+// missing from S3 are removed locally, not re-uploaded.
+func TestSyncAllToS3_CleansOrphanedHTTP01Token(t *testing.T) {
+	fc, _ := newTestFallbackCache(t)
+	ctx := context.Background()
+
+	const tok = "sometoken+http-01"
+	if err := fc.fallback.Put(ctx, tok, []byte("challenge-response")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fc.SyncAllToS3(ctx); err != nil {
+		t.Fatalf("SyncAllToS3: %v", err)
+	}
+
+	if _, err := fc.fallback.Get(ctx, tok); err != autocert.ErrCacheMiss {
+		t.Errorf("orphaned http-01 token should be deleted locally, got err=%v", err)
+	}
+	if _, err := fc.primary.Get(ctx, tok); err != autocert.ErrCacheMiss {
+		t.Error("orphaned http-01 token should NOT be uploaded to S3")
+	}
+}
+
+// TestGet_ReturnsCacheMissOnS3Error verifies a transient S3 error surfaces as
+// ErrCacheMiss so autocert can still fall through to issuance.
+func TestGet_ReturnsCacheMissOnS3Error(t *testing.T) {
+	fc, mock := newTestFallbackCache(t)
+	mock.GetErr = errors.New("s3 network failure")
+
+	_, err := fc.Get(context.Background(), "uncached.example.com")
+	if err != autocert.ErrCacheMiss {
+		t.Errorf("expected ErrCacheMiss on S3 error, got %v", err)
+	}
+}
+
+func TestCertNotAfter(t *testing.T) {
+	want := time.Now().Add(42 * 24 * time.Hour).Truncate(time.Second)
+	got, ok := certNotAfter(makeCertPEM(t, want))
+	if !ok || !got.Equal(want) {
+		t.Errorf("certNotAfter = %v, %v; want %v, true", got, ok, want)
+	}
+	if _, ok := certNotAfter([]byte("not a cert")); ok {
+		t.Error("certNotAfter should return ok=false for non-certificate data")
+	}
+}


### PR DESCRIPTION
Three self-contained correctness fixes in the S3/local certificate fallback cache.

### 1. Stale resurrection on sync (high)
`SyncAllToS3` uploaded the local copy whenever it differed byte-for-byte from S3, with no notion of which is newer:
```go
// Different certificate - need to sync
f.primary.Put(ctx, name, data)
```
A non-leader node that restarts with a **pre-renewal** cert on disk would push it over a freshly-renewed cert in S3, resurrecting the old cert cluster-wide (this sync runs on every node at startup). Now certificate bundles are compared by `NotAfter`: if S3 is **newer**, the local copy is refreshed **from** S3 (so the node stops serving the stale cert) and S3 is left untouched; only a newer local cert is synced up.

### 2. Handshake aborts on transient S3 errors (medium)
`FallbackCache.Get` returned the raw S3 transport error. autocert treats any non-`ErrCacheMiss` error from `Get` as fatal for the handshake — it does **not** fall through to certificate issuance — so a flapping S3 aborted handshakes for uncached domains that could otherwise have triggered issuance. Now returns `autocert.ErrCacheMiss` after logging, matching the circuit-breaker-open path.

### 3. Orphaned http-01 tokens accumulate (medium)
The cleanup of completed challenge tokens matched only the tls-alpn suffix (`+token`). This deployment uses **http-01** (`HTTPHandler`), whose tokens are stored as `<token>+http-01` — so they were never cleaned and got re-uploaded to S3. Now matches both suffixes.

## Verification

- `go build ./...`, `go vet`, and new `go test ./tlsmanager/storage/` pass.
- Tests (mock S3 + real `DirCache`): stale local doesn't overwrite newer S3 (and local is refreshed); newer local is pushed up; orphaned `+http-01` token is deleted locally and not uploaded; `Get` returns `ErrCacheMiss` on S3 error; `certNotAfter` parsing.

## Out of scope (follow-up)

The deeper coordination issues from the review — gating Let's Encrypt **issuance** at `GetCertificate` rather than `Cache.Put` (autocert performs the ACME order before `Put` and ignores `Put` errors, so the leader gate can't actually prevent duplicate issuance), and per-handshake S3→local freshness — require a redesign validated against a **real cluster and ACME**, which can't be done safely here. This PR fixes the pieces that are correct-by-construction and unit-testable; the architectural change is called out for a dedicated, cluster-tested change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)