### PR TITLE
Maildir: honor mboxType on append, fix unseen count and sort order

### DIFF
--- a/provider/maildir/messages.go
+++ b/provider/maildir/messages.go
@@ -161,6 +161,28 @@ func getAllMessages(dir maildir.Dir) ([]*maildir.Message, error) {
 	return msgs, err
 }
 
+// countUnseen returns the number of messages that do not carry the \Seen flag.
+// go-maildir's UnseenCount counts files in new/ (the "recently delivered" set),
+// but getAllMessages empties new/ by moving those files to cur/, so after the
+// first listing UnseenCount would always report 0. IMAP's NumUnseen means "no
+// \Seen flag", so count that directly.
+func countUnseen(msgs []*maildir.Message) int {
+	n := 0
+	for _, m := range msgs {
+		seen := false
+		for _, fl := range m.Flags() {
+			if fl == maildir.FlagSeen {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			n++
+		}
+	}
+	return n
+}
+
 func (p *Provider) ListMessages(mailbox string, sortOrder string, page, pageSize int) ([]provider.Message, int, error) {
 	dir := p.getDir(mailbox)
 	msgs, err := getAllMessages(dir)
@@ -169,7 +191,7 @@ func (p *Provider) ListMessages(mailbox string, sortOrder string, page, pageSize
 	}
 
 	sort.Slice(msgs, func(i, j int) bool {
-		if sortOrder == "date-asc" {
+		if sortOrder == "asc" {
 			return msgs[i].Key() < msgs[j].Key()
 		}
 		return msgs[i].Key() > msgs[j].Key()
@@ -251,7 +273,7 @@ func (p *Provider) SearchMessages(mailbox, query string, sortOrder string, page,
 	}
 
 	sort.Slice(matchedMsgs, func(i, j int) bool {
-		if sortOrder == "date-asc" {
+		if sortOrder == "asc" {
 			return matchedMsgs[i].Key() < matchedMsgs[j].Key()
 		}
 		return matchedMsgs[i].Key() > matchedMsgs[j].Key()
@@ -494,7 +516,27 @@ func (p *Provider) MarkAnswered(mailbox string, id provider.MessageID) error {
 }
 
 func (p *Provider) AppendMessage(mailbox string, msg provider.OutgoingMessageWriter, mboxType provider.MailboxType) (*provider.Mailbox, provider.MessageID, uint32, error) {
+	// The adapter passes an empty mailbox and selects the destination by type
+	// (Sent/Drafts/...), matching the IMAP backend. Resolve it here — the old
+	// code ignored mboxType entirely and delivered everything to INBOX.
+	if mailbox == "" {
+		if mbox, err := p.FindMailboxByType(mboxType); err == nil && mbox != nil {
+			mailbox = mbox.Name
+		} else {
+			name, nerr := mailboxNameForType(mboxType)
+			if nerr != nil {
+				return nil, nil, 0, nerr
+			}
+			mailbox = name
+		}
+	}
+
 	dir := p.getDir(mailbox)
+	// Ensure the destination maildir exists (creates tmp/new/cur); a Sent or
+	// Drafts folder may not have been created yet.
+	if err := dir.Init(); err != nil {
+		return nil, nil, 0, fmt.Errorf("failed to initialize maildir %q: %w", mailbox, err)
+	}
 
 	delivery, err := maildir.NewDelivery(string(dir))
 	if err != nil {
@@ -507,12 +549,15 @@ func (p *Provider) AppendMessage(mailbox string, msg provider.OutgoingMessageWri
 		return nil, nil, 0, err
 	}
 
-	err = delivery.Close()
-	if err != nil {
+	if err := delivery.Close(); err != nil {
 		return nil, nil, 0, err
 	}
 
-	return nil, nil, uint32(size), nil
+	// go-maildir's Delivery does not expose the resulting message key, so we
+	// return an empty MessageID; callers treat the subsequent metadata fetch as
+	// best-effort. Crucially, the mailbox is non-nil (the adapter dereferences
+	// it), which previously panicked.
+	return &provider.Mailbox{Name: mailbox, Delimiter: '.', Subscribed: true}, MaildirMessageID(""), uint32(size), nil
 }
 
 func (p *Provider) DeleteMessages(mailbox string, ids []provider.MessageID) error {

--- a/provider/maildir/provider.go
+++ b/provider/maildir/provider.go
@@ -42,13 +42,12 @@ func (p *Provider) ListMailboxes() ([]provider.Mailbox, error) {
 
 	// Add INBOX
 	inbox := p.getDir("INBOX")
-	inboxUnseen, _ := inbox.UnseenCount()
 	inboxMsgs, _ := getAllMessages(inbox)
 	mailboxes = append(mailboxes, provider.Mailbox{
 		Name:       "INBOX",
 		Delimiter:  '.',
 		Total:      len(inboxMsgs),
-		Unseen:     inboxUnseen,
+		Unseen:     countUnseen(inboxMsgs),
 		Subscribed: true,
 	})
 
@@ -69,14 +68,13 @@ func (p *Provider) ListMailboxes() ([]provider.Mailbox, error) {
 
 		folderName := strings.TrimPrefix(entry.Name(), ".")
 		dir := p.getDir(folderName)
-		unseen, _ := dir.UnseenCount()
 		msgs, _ := getAllMessages(dir)
 
 		mailboxes = append(mailboxes, provider.Mailbox{
 			Name:       folderName,
 			Delimiter:  '.',
 			Total:      len(msgs),
-			Unseen:     unseen,
+			Unseen:     countUnseen(msgs),
 			Subscribed: true, // Assume all are subscribed for now
 		})
 	}
@@ -86,10 +84,6 @@ func (p *Provider) ListMailboxes() ([]provider.Mailbox, error) {
 
 func (p *Provider) GetMailboxStatus(name string) (*provider.MailboxStatus, error) {
 	dir := p.getDir(name)
-	unseen, err := dir.UnseenCount()
-	if err != nil {
-		return nil, err
-	}
 	msgs, err := getAllMessages(dir)
 	if err != nil {
 		return nil, err
@@ -98,8 +92,26 @@ func (p *Provider) GetMailboxStatus(name string) (*provider.MailboxStatus, error
 	return &provider.MailboxStatus{
 		Name:        name,
 		NumMessages: uint32(len(msgs)),
-		NumUnseen:   uint32(unseen),
+		NumUnseen:   uint32(countUnseen(msgs)),
 	}, nil
+}
+
+// mailboxNameForType maps a special-use mailbox type to its canonical folder name.
+func mailboxNameForType(mboxType provider.MailboxType) (string, error) {
+	switch mboxType {
+	case provider.MailboxTypeSent:
+		return "Sent", nil
+	case provider.MailboxTypeDrafts:
+		return "Drafts", nil
+	case provider.MailboxTypeTrash:
+		return "Trash", nil
+	case provider.MailboxTypeJunk:
+		return "Junk", nil
+	case provider.MailboxTypeArchive:
+		return "Archive", nil
+	default:
+		return "", fmt.Errorf("unknown mailbox type %v", mboxType)
+	}
 }
 
 func (p *Provider) FindMailboxByType(mboxType provider.MailboxType) (*provider.Mailbox, error) {
@@ -108,20 +120,9 @@ func (p *Provider) FindMailboxByType(mboxType provider.MailboxType) (*provider.M
 		return nil, err
 	}
 
-	var targetName string
-	switch mboxType {
-	case provider.MailboxTypeSent:
-		targetName = "Sent"
-	case provider.MailboxTypeDrafts:
-		targetName = "Drafts"
-	case provider.MailboxTypeTrash:
-		targetName = "Trash"
-	case provider.MailboxTypeJunk:
-		targetName = "Junk"
-	case provider.MailboxTypeArchive:
-		targetName = "Archive"
-	default:
-		return nil, fmt.Errorf("unknown mailbox type")
+	targetName, err := mailboxNameForType(mboxType)
+	if err != nil {
+		return nil, err
 	}
 
 	for _, m := range mailboxes {

--- a/provider/maildir/provider_test.go
+++ b/provider/maildir/provider_test.go
@@ -94,16 +94,19 @@ func TestProviderMessages(t *testing.T) {
 	msgContent := []byte("From: test@example.com\r\nTo: user@example.com\r\nSubject: Test Subject\r\n\r\nThis is a test message body.")
 	msg := &mockMessage{content: msgContent}
 
-	_, _, size, err := p.AppendMessage("INBOX", msg, 0)
+	mbox, _, size, err := p.AppendMessage("INBOX", msg, 0)
 	if err != nil {
 		t.Fatalf("AppendMessage failed: %v", err)
+	}
+	if mbox == nil {
+		t.Fatal("AppendMessage returned a nil mailbox (would panic in the adapter)")
 	}
 	if size == 0 {
 		t.Errorf("AppendMessage returned size 0")
 	}
 
 	// 2. Test ListMessages
-	msgs, total, err := p.ListMessages("INBOX", "date-desc", 0, 10)
+	msgs, total, err := p.ListMessages("INBOX", "desc", 0, 10)
 	if err != nil {
 		t.Fatalf("ListMessages failed: %v", err)
 	}
@@ -117,7 +120,7 @@ func TestProviderMessages(t *testing.T) {
 	}
 
 	// 3. Test SearchMessages
-	_, searchTotal, err := p.SearchMessages("INBOX", "test message body", "date-desc", 0, 10)
+	_, searchTotal, err := p.SearchMessages("INBOX", "test message body", "desc", 0, 10)
 	if err != nil {
 		t.Fatalf("SearchMessages failed: %v", err)
 	}
@@ -133,6 +136,9 @@ func TestProviderMessages(t *testing.T) {
 	if status.NumMessages != 1 {
 		t.Errorf("Expected 1 message in status, got %d", status.NumMessages)
 	}
+	if status.NumUnseen != 1 {
+		t.Errorf("Expected 1 unseen message before marking seen, got %d", status.NumUnseen)
+	}
 
 	// 5. Test Flags
 	if err := p.SetMessagesFlags("INBOX", []provider.MessageID{firstMsg.ID}, provider.FlagOperation{
@@ -142,7 +148,7 @@ func TestProviderMessages(t *testing.T) {
 		t.Fatalf("SetMessagesFlags failed: %v", err)
 	}
 
-	msgs, _, _ = p.ListMessages("INBOX", "date-desc", 0, 10)
+	msgs, _, _ = p.ListMessages("INBOX", "desc", 0, 10)
 	hasSeen := false
 	for _, f := range msgs[0].Flags {
 		if f == provider.FlagSeen {
@@ -153,13 +159,55 @@ func TestProviderMessages(t *testing.T) {
 		t.Errorf("Message flags did not include \\Seen after update")
 	}
 
+	// Unseen count must drop to 0 now that the only message is \Seen. Before the
+	// fix this stayed at whatever new/ held and could not reflect the flag.
+	if status, err := p.GetMailboxStatus("INBOX"); err != nil {
+		t.Fatalf("GetMailboxStatus failed: %v", err)
+	} else if status.NumUnseen != 0 {
+		t.Errorf("Expected 0 unseen after marking the message seen, got %d", status.NumUnseen)
+	}
+
 	// 6. Test DeleteMessages
 	if err := p.DeleteMessages("INBOX", []provider.MessageID{firstMsg.ID}); err != nil {
 		t.Fatalf("DeleteMessages failed: %v", err)
 	}
 
-	msgs, total, _ = p.ListMessages("INBOX", "date-desc", 0, 10)
+	msgs, total, _ = p.ListMessages("INBOX", "desc", 0, 10)
 	if total != 0 {
 		t.Errorf("Expected 0 messages after delete, got %d", total)
+	}
+}
+
+// TestMaildir_SortOrderAscending verifies "asc" actually sorts ascending. The
+// callers pass "asc"/"desc" (frontend values); the maildir code previously
+// checked for "date-asc", so "asc" was ignored and always sorted descending.
+func TestMaildir_SortOrderAscending(t *testing.T) {
+	tmpDir := t.TempDir()
+	p := NewProvider(tmpDir, "testuser")
+	if err := p.getDir("INBOX").Init(); err != nil {
+		t.Fatalf("init INBOX: %v", err)
+	}
+
+	for _, subj := range []string{"First", "Second"} {
+		content := []byte("From: a@example.com\r\nSubject: " + subj + "\r\n\r\nbody")
+		if _, _, _, err := p.AppendMessage("INBOX", &mockMessage{content: content}, 0); err != nil {
+			t.Fatalf("append %s: %v", subj, err)
+		}
+	}
+
+	desc, _, err := p.ListMessages("INBOX", "desc", 0, 10)
+	if err != nil || len(desc) != 2 {
+		t.Fatalf("desc list: err=%v n=%d", err, len(desc))
+	}
+	asc, _, err := p.ListMessages("INBOX", "asc", 0, 10)
+	if err != nil || len(asc) != 2 {
+		t.Fatalf("asc list: err=%v n=%d", err, len(asc))
+	}
+
+	if desc[0].Envelope.Subject != asc[1].Envelope.Subject ||
+		desc[1].Envelope.Subject != asc[0].Envelope.Subject {
+		t.Errorf("asc order should reverse desc: desc=[%s,%s] asc=[%s,%s]",
+			desc[0].Envelope.Subject, desc[1].Envelope.Subject,
+			asc[0].Envelope.Subject, asc[1].Envelope.Subject)
 	}
 }


### PR DESCRIPTION
Three correctness fixes in the maildir backend (used when `provider.type = maildir`; the IMAP backend is unaffected).

### 1. AppendMessage ignored mboxType and returned a nil mailbox (critical for maildir)
The adapter calls `AppendMessage("", msg, mboxType)` — empty mailbox, destination selected by type. But maildir did `getDir("")` (→ INBOX) and ignored `mboxType`, so **every Sent copy and saved Draft was delivered to INBOX**. It also returned `nil` for the mailbox, which the adapter dereferences (`providerMailboxToInfo(*mbox)`) → panic (recovered as a failed request). Sending and draft-saving were broken. Now the destination is resolved from `mboxType` (via `FindMailboxByType`, falling back to the canonical name and `Init()`-ing the maildir if it doesn't exist), and a non-nil mailbox is returned.

### 2. Unseen count collapsed to 0 (high)
`ListMailboxes`/`GetMailboxStatus` used `dir.UnseenCount()`, which counts files in `new/`. But `getAllMessages` calls `dir.Unseen()`, moving `new/` → `cur/` on every listing — so after the first list, `UnseenCount()` returned 0 regardless of `\Seen` state, and unread badges showed 0 permanently. Now counts messages lacking the `\Seen` flag, matching IMAP's `NumUnseen`.

### 3. Ascending sort silently did nothing (high)
The sort compared `sortOrder == "date-asc"`, but callers pass `"asc"`/`"desc"` (the IMAP backend checks `"asc"`). Toggling to ascending had no effect. Now compares `"asc"`.

## Verification

- `go build ./...`, `go vet`, and `go test ./provider/...` pass.
- Tests updated to use the real `"asc"`/`"desc"` values (they passed `"date-desc"`, which masked the sort bug). New coverage: append returns a non-nil mailbox; unseen count is 1 before and 0 after marking the message `\Seen`; `"asc"` reverses `"desc"` ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)