### PR TITLE
Cleanup: remove dead helpers, simplify nits, fix Makefile .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean build install build-freebsd build-linux help
+.PHONY: all clean build build-frontend install build-freebsd build-linux help test test-coverage
 
 # Binary names
 ALPS_BINARY ?= build/alps

--- a/cmd/alps/config.go
+++ b/cmd/alps/config.go
@@ -342,7 +342,7 @@ func (c *Config) ToOptions() (alps.Options, error) {
 	}
 
 	// Override rate limiting config from config file
-	if c.Server.RateLimit.Enabled != nil && *c.Server.RateLimit.Enabled == false {
+	if c.Server.RateLimit.Enabled != nil && !*c.Server.RateLimit.Enabled {
 		options.RateLimitEnabled = false
 		options.RateLimitConfig = nil
 	} else {

--- a/plugins/base/provider_adapter.go
+++ b/plugins/base/provider_adapter.go
@@ -236,16 +236,6 @@ func deleteMailboxWithProvider(p provider.MailProvider, name string) error {
 	return p.DeleteMailbox(name)
 }
 
-// getMessagePartWithDataWithProvider gets a message part with data using the provider
-func getMessagePartWithDataWithProvider(p provider.MailProvider, mailbox string, uid provider.MessageID, partPath []int) (*IMAPMessage, []byte, []byte, error) {
-	msg, _, headerData, bodyData, err := p.GetMessagePartWithData(mailbox, uid, partPath)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	imapMsg := providerMessageToIMAP(*msg)
-	return &imapMsg, headerData, bodyData, nil
-}
-
 // setMessageFlagsWithProvider sets message flags using the provider
 func setMessageFlagsWithProvider(p provider.MailProvider, mailbox string, uids []provider.MessageID, op provider.FlagOp, flags []provider.Flag) error {
 	flagOp := provider.FlagOperation{

--- a/plugins/base/routes.go
+++ b/plugins/base/routes.go
@@ -1634,29 +1634,6 @@ func handleCancelAttachment(ctx *alps.Context) error {
 	return ctx.JSON(http.StatusOK, nil)
 }
 
-func unwrapIMAPAddressList(addrs []imap.Address) []string {
-	l := make([]string, len(addrs))
-	for i, addr := range addrs {
-		l[i] = unwrapIMAPAddress(addr)
-	}
-	return l
-}
-
-func unwrapIMAPAddress(addr imap.Address) string {
-	address := addr.Addr()
-	if addr.Name != "" {
-		address = fmt.Sprintf("%q <%s>", addr.Name, address)
-	}
-	return address
-}
-
-func formatMsgIDList(l []string) string {
-	if len(l) == 0 {
-		return ""
-	}
-	return "<" + strings.Join(l, ">, <") + ">"
-}
-
 func formOrQueryParam(ctx *alps.Context, k string) string {
 	if v := ctx.FormValue(k); v != "" {
 		return v
@@ -1957,7 +1934,7 @@ func handleSetFlags(ctx *alps.Context) error {
 		}
 
 		uids = formParams["uids"]
-		flags, _ = formParams["flags"]
+		flags = formParams["flags"]
 		if len(flags) == 0 {
 			flagsStr := ctx.QueryParam("to")
 			if flagsStr == "" {

--- a/plugins/base/search.go
+++ b/plugins/base/search.go
@@ -16,19 +16,6 @@ func searchCriteriaHeader(k, v string) *imap.SearchCriteria {
 	}
 }
 
-func searchCriteriaOr(criteria ...*imap.SearchCriteria) *imap.SearchCriteria {
-	if criteria[0] == nil {
-		criteria = criteria[1:]
-	}
-	or := criteria[0]
-	for _, c := range criteria[1:] {
-		or = &imap.SearchCriteria{
-			Or: [][2]imap.SearchCriteria{{*or, *c}},
-		}
-	}
-	return or
-}
-
 func searchCriteriaAnd(criteria ...*imap.SearchCriteria) *imap.SearchCriteria {
 	if criteria[0] == nil {
 		criteria = criteria[1:]


### PR DESCRIPTION
Low-risk cleanup based on `staticcheck` findings.

- **Remove unused internal helpers (U1000)** — all confirmed to have no callers:
  - `unwrapIMAPAddressList`, `unwrapIMAPAddress`, `formatMsgIDList` (plugins/base/routes.go)
  - `searchCriteriaOr` (plugins/base/search.go)
  - `getMessagePartWithDataWithProvider` (plugins/base/provider_adapter.go)
- **Simplify nits**: comparison to a bool constant (`== false` → `!`, config.go, S1002); drop an unnecessary comma-ok blank on a map read (routes.go, S1005).
- **Makefile**: add the missing phony targets (`build-frontend`, `test`, `test-coverage`) to `.PHONY`.

**Left in place:** the unused `handleDisable` / `handleTrustLinkedAccounts` in webauthn.go. They read as intended-but-not-yet-wired feature handlers (disable 2FA, trust linked accounts) rather than stale code, so removing them is a product decision I left to the maintainer.

## Verification

- `go build ./...`, `go vet ./...`, and full `go test ./...` pass. The removed functions had zero references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)