### PR TITLE
tls: proactive leader-side issuance, store freshness, and safety prerequisites (stage 1/2)

### DIFF
--- a/cmd/alps/config.go
+++ b/cmd/alps/config.go
@@ -154,6 +154,8 @@ type LetsEncryptConfig struct {
 	CacheDir            string          `toml:"cache_dir"`             // Directory for local file cache
 	SyncIntervalMinutes int             `toml:"sync_interval_minutes"` // Interval for syncing local cache to S3
 	ACMEHTTPAddr        string          `toml:"acme_http_addr"`        // Address for HTTP-01 challenges (default: ":80")
+	DirectoryURL        string          `toml:"directory_url"`         // ACME directory URL; empty = Let's Encrypt production. Non-production URLs get an isolated, namespaced cert store.
+	WarmRSACerts        bool            `toml:"warm_rsa_certs"`        // Also pre-issue legacy RSA certificates (default: ECDSA only)
 	S3                  S3StorageConfig `toml:"s3"`
 }
 

--- a/cmd/alps/main.go
+++ b/cmd/alps/main.go
@@ -147,12 +147,16 @@ func main() {
 			Logger:        slog.Default(),
 		})
 		if err != nil {
-			logger.Errorf("failed to initialize cluster (falling back to single-node mode): %v", err)
-			clusterMgr = nil
-		} else {
-			defer clusterMgr.Shutdown()
-			options.ClusterBroadcaster = clusterMgr
+			// Fatal, not a silent single-node fallback: with clustering
+			// configured, a node without a leadership signal would treat
+			// itself as a standalone instance — including issuing Let's
+			// Encrypt certificates ungated and writing to the shared cert
+			// store. A fleet-wide config error (e.g. missing secret key)
+			// would then turn EVERY node into an independent issuer.
+			logger.Fatalf("failed to initialize cluster (clustering is enabled in config, refusing to run ungated): %v", err)
 		}
+		defer clusterMgr.Shutdown()
+		options.ClusterBroadcaster = clusterMgr
 	}
 
 	s, err := alps.New(logger, &options)
@@ -194,6 +198,10 @@ func main() {
 		tlsCfg, err := buildTLSConfig(config.TLS)
 		if err != nil {
 			logger.Fatalf("Failed to build TLS config: %v", err)
+		}
+
+		if err := validateClusterTLS(config.Cluster.Enabled, tlsCfg); err != nil {
+			logger.Fatalf("%v", err)
 		}
 
 		// Create slog logger from alps logger for TLS manager
@@ -292,6 +300,18 @@ func main() {
 	s.Close()
 }
 
+// validateClusterTLS rejects configurations where clustered nodes would have
+// no shared certificate source. Clustered Let's Encrypt requires S3 storage:
+// with "file" storage each node has a private cert directory the leader never
+// writes to, so followers have no certificate source at all.
+func validateClusterTLS(clusterEnabled bool, tlsCfg *tlsmanager.Config) error {
+	if clusterEnabled && tlsCfg.Provider == tlsmanager.ProviderLetsEncrypt &&
+		tlsCfg.LetsEncrypt != nil && tlsCfg.LetsEncrypt.StorageProvider != "s3" {
+		return fmt.Errorf("TLS letsencrypt storage_provider must be \"s3\" when clustering is enabled (got %q): file storage is node-local and cannot be shared across the cluster", tlsCfg.LetsEncrypt.StorageProvider)
+	}
+	return nil
+}
+
 // buildTLSConfig converts the config file TLS config to tlsmanager.Config
 func buildTLSConfig(cfg TLSConfig) (*tlsmanager.Config, error) {
 	tlsCfg := &tlsmanager.Config{
@@ -312,14 +332,20 @@ func buildTLSConfig(cfg TLSConfig) (*tlsmanager.Config, error) {
 
 	// Build Let's Encrypt config if using that provider
 	if tlsCfg.Provider == tlsmanager.ProviderLetsEncrypt {
+		storageProvider := cfg.LetsEncrypt.StorageProvider
+		if storageProvider == "" {
+			storageProvider = "s3" // Documented default
+		}
 		tlsCfg.LetsEncrypt = &tlsmanager.LetsEncryptConfig{
 			Email:               cfg.LetsEncrypt.Email,
 			Domains:             cfg.LetsEncrypt.Domains,
 			DefaultDomain:       cfg.LetsEncrypt.DefaultDomain,
-			StorageProvider:     cfg.LetsEncrypt.StorageProvider,
+			StorageProvider:     storageProvider,
 			CacheDir:            cfg.LetsEncrypt.CacheDir,
 			SyncIntervalMinutes: cfg.LetsEncrypt.SyncIntervalMinutes,
 			ACMEHTTPAddr:        cfg.LetsEncrypt.ACMEHTTPAddr,
+			DirectoryURL:        cfg.LetsEncrypt.DirectoryURL,
+			WarmRSACerts:        cfg.LetsEncrypt.WarmRSACerts,
 			S3: tlsmanager.S3Config{
 				Endpoint:  cfg.LetsEncrypt.S3.Endpoint,
 				Bucket:    cfg.LetsEncrypt.S3.Bucket,

--- a/cmd/alps/main_test.go
+++ b/cmd/alps/main_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/migadu/alps/tlsmanager"
+)
+
+func TestBuildTLSConfig_DefaultStorageProvider(t *testing.T) {
+	cfg := TLSConfig{
+		Enabled:  true,
+		Provider: "letsencrypt",
+		LetsEncrypt: LetsEncryptConfig{
+			Email:   "admin@example.com",
+			Domains: []string{"mail.example.com"},
+		},
+	}
+	tlsCfg, err := buildTLSConfig(cfg)
+	if err != nil {
+		t.Fatalf("buildTLSConfig: %v", err)
+	}
+	if got := tlsCfg.LetsEncrypt.StorageProvider; got != "s3" {
+		t.Errorf("empty storage_provider should default to \"s3\", got %q", got)
+	}
+}
+
+func TestValidateClusterTLS(t *testing.T) {
+	le := func(storage string) *tlsmanager.Config {
+		return &tlsmanager.Config{
+			Provider:    tlsmanager.ProviderLetsEncrypt,
+			LetsEncrypt: &tlsmanager.LetsEncryptConfig{StorageProvider: storage},
+		}
+	}
+
+	if err := validateClusterTLS(true, le("file")); err == nil {
+		t.Error("cluster + letsencrypt file storage must be rejected: followers would have no certificate source")
+	}
+	if err := validateClusterTLS(true, le("s3")); err != nil {
+		t.Errorf("cluster + s3 storage should be valid: %v", err)
+	}
+	if err := validateClusterTLS(false, le("file")); err != nil {
+		t.Errorf("single-instance file storage should be valid: %v", err)
+	}
+	if err := validateClusterTLS(true, &tlsmanager.Config{Provider: tlsmanager.ProviderFile}); err != nil {
+		t.Errorf("cluster + file TLS provider (static certs) should be valid: %v", err)
+	}
+}

--- a/config.example.toml
+++ b/config.example.toml
@@ -290,6 +290,24 @@ level = "info"
 # Your proxy should forward /.well-known/acme-challenge/* to this address.
 # acme_http_addr = ":8080"
 
+# ACME directory URL (default: Let's Encrypt production).
+# Set to the Let's Encrypt staging directory to test certificate issuance
+# without burning production rate limits:
+#   directory_url = "https://acme-staging-v02.api.letsencrypt.org/directory"
+# When a non-production directory is configured, the local cache directory and
+# S3 prefix are automatically namespaced (suffix derived from the URL) so
+# staging certificates can never be served from, or overwrite, the production
+# certificate store.
+# directory_url = ""
+
+# Also pre-issue the legacy RSA certificate flavor alongside ECDSA
+# (default: false). Only needed if you must support very old clients that
+# cannot do ECDSA; doubles the number of certificates issued per domain.
+# Upgrade note: deployments whose cached certificates are RSA-only (issued
+# historically by handshakes from non-ECDSA clients) will obtain one new
+# ECDSA certificate per domain on the first warm pass after upgrading.
+# warm_rsa_certs = false
+
 [tls.letsencrypt.s3]
 # S3 storage configuration for certificates
 # Uses autocert with S3 storage as the primary source of truth.
@@ -312,7 +330,15 @@ level = "info"
 
 
 [cluster]
-# Optional - only needed for Let's Encrypt with S3 storage and multiple ALPS nodes
+# Optional - only needed for Let's Encrypt with S3 storage and multiple ALPS nodes.
+# Notes when enabled:
+#  - TLS letsencrypt storage_provider must be "s3" (enforced at startup);
+#    file storage is node-local and cannot be shared across the cluster.
+#  - A cluster initialization failure is fatal. Nodes do NOT silently fall
+#    back to single-node mode, since an ungated node would issue Let's
+#    Encrypt certificates on its own.
+#  - When deploying new versions, restart the current cluster leader first
+#    (leadership is pinned to the lexicographically smallest node_id).
 enabled = false
 # node_id = "node-1"                            # Unique identifier for this node
 # bind = "0.0.0.0"                              # Can be "IP:port" or just "IP" (default: 0.0.0.0)

--- a/tlsmanager/manager.go
+++ b/tlsmanager/manager.go
@@ -2,12 +2,14 @@ package tlsmanager
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
+	"path"
 	"strings"
 	"time"
 
@@ -16,6 +18,7 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
 
 	"github.com/migadu/alps/tlsmanager/storage"
@@ -50,6 +53,8 @@ type LetsEncryptConfig struct {
 	CacheDir            string // Directory for local file cache
 	SyncIntervalMinutes int    // Interval for syncing local cache to S3
 	ACMEHTTPAddr        string // Address for HTTP-01 challenge handler (e.g., ":8080")
+	DirectoryURL        string // ACME directory URL; empty = Let's Encrypt production. When set to a non-production URL the certificate store is automatically namespaced so staging certs can never poison the production cache.
+	WarmRSACerts        bool   // Also pre-issue the legacy RSA certificate flavor (default: ECDSA only)
 	S3                  S3Config
 }
 
@@ -71,6 +76,9 @@ type Manager struct {
 	defaultDomain   string                  // Default domain for SNI-less connections
 	syncWorker      *storage.CertSyncWorker // Periodic S3 sync worker (nil if not using S3)
 	tlsConfig       *tls.Config             // Cached TLS config
+	fallbackCache   *storage.FallbackCache  // Retained for follower refresh / warmer S3-health checks (nil unless S3 storage)
+	isLeader        func() bool             // Cluster leadership; nil in single-instance mode
+	warmer          *certWarmer             // Proactive issuance/renewal loop (nil unless Let's Encrypt)
 }
 
 // NewManager creates a new TLS manager.
@@ -94,6 +102,26 @@ func NewManager(cfg *Config, logger *slog.Logger, isLeaderF ...func() bool) (*Ma
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", cfg.Provider)
 	}
+}
+
+// namespacedStorageConfig isolates the certificate store when a non-production
+// ACME directory (e.g. Let's Encrypt staging) is configured. Certs are keyed by
+// bare domain name and every node treats the store as source of truth, so a
+// staging cert in the production store would be served cluster-wide. The local
+// dir and S3 prefix are suffixed with a hash of the directory URL, making
+// cross-poisoning impossible by construction rather than operator discipline.
+func namespacedStorageConfig(cfg LetsEncryptConfig) (LetsEncryptConfig, bool) {
+	if cfg.DirectoryURL == "" || cfg.DirectoryURL == autocert.DefaultACMEDirectory {
+		return cfg, false
+	}
+	sum := sha256.Sum256([]byte(cfg.DirectoryURL))
+	suffix := fmt.Sprintf("acme-%x", sum[:4])
+	if cfg.CacheDir == "" {
+		cfg.CacheDir = "cert-cache"
+	}
+	cfg.CacheDir += "-" + suffix
+	cfg.S3.Prefix = path.Join(cfg.S3.Prefix, suffix)
+	return cfg, true
 }
 
 func (m *Manager) initFileProvider() error {
@@ -125,24 +153,33 @@ func (m *Manager) initAutocert(isLeaderF ...func() bool) error {
 		return errors.New("email required")
 	}
 
+	storageCfg, namespaced := namespacedStorageConfig(*cfg)
+	if namespaced {
+		m.logger.Warn("using non-default ACME directory - certificate store namespaced to keep it isolated from production",
+			"directory_url", cfg.DirectoryURL,
+			"cache_dir", storageCfg.CacheDir,
+			"s3_prefix", storageCfg.S3.Prefix)
+	}
+
 	var cache autocert.Cache
 	var syncWorker *storage.CertSyncWorker
 
 	switch cfg.StorageProvider {
 	case "s3":
 		// Create S3 cache
-		s3Cache, err := createS3Cache(context.Background(), *cfg, m.logger)
+		s3Cache, err := createS3Cache(context.Background(), storageCfg, m.logger)
 		if err != nil {
 			return err
 		}
 
 		// Create fallback cache (local file + S3) for hybrid storage
-		cacheDir := cfg.CacheDir
+		cacheDir := storageCfg.CacheDir
 		if cacheDir == "" {
 			cacheDir = "cert-cache" // Default local cache directory
 		}
 		fallbackCache := storage.NewFallbackCache(cacheDir, s3Cache, m.logger)
 		cache = fallbackCache
+		m.fallbackCache = fallbackCache
 
 		// Start periodic sync worker
 		syncInterval := time.Duration(cfg.SyncIntervalMinutes) * time.Minute
@@ -152,7 +189,7 @@ func (m *Manager) initAutocert(isLeaderF ...func() bool) error {
 		syncWorker = storage.NewCertSyncWorker(fallbackCache, syncInterval, m.logger)
 		syncWorker.Start()
 
-		prefixInfo := cfg.S3.Prefix
+		prefixInfo := storageCfg.S3.Prefix
 		if prefixInfo == "" {
 			prefixInfo = "(none - bucket root)"
 		}
@@ -164,7 +201,7 @@ func (m *Manager) initAutocert(isLeaderF ...func() bool) error {
 
 	case "file":
 		// Use autocert.DirCache for local filesystem storage only
-		cacheDir := cfg.CacheDir
+		cacheDir := storageCfg.CacheDir
 		if cacheDir == "" {
 			cacheDir = "cert-cache"
 		}
@@ -184,12 +221,16 @@ func (m *Manager) initAutocert(isLeaderF ...func() bool) error {
 	} else {
 		m.logger.Info("TLS running in single-instance mode (no cluster leader election)")
 	}
+	m.isLeader = leaderFunc
 
 	autocertMgr := &autocert.Manager{
 		Prompt:     autocert.AcceptTOS,
 		HostPolicy: autocert.HostWhitelist(cfg.Domains...),
 		Cache:      cache,
 		Email:      cfg.Email,
+	}
+	if cfg.DirectoryURL != "" {
+		autocertMgr.Client = &acme.Client{DirectoryURL: cfg.DirectoryURL}
 	}
 
 	// Determine default domain for SNI-less connections
@@ -249,6 +290,13 @@ func (m *Manager) initAutocert(isLeaderF ...func() bool) error {
 
 	m.tlsConfig = baseTLSConfig
 
+	// Proactively issue/renew certificates for all configured domains so the
+	// shared store is always populated regardless of which node receives
+	// traffic. In a cluster only the leader runs warm passes; in
+	// single-instance mode the sole node does.
+	m.warmer = newCertWarmer(m, cfg.Domains, cfg.WarmRSACerts)
+	m.warmer.Start()
+
 	m.logger.Info("TLS manager initialized",
 		"domains", cfg.Domains,
 		"email", cfg.Email,
@@ -283,6 +331,9 @@ func (m *Manager) Close() error {
 		return nil
 	}
 
+	if m.warmer != nil {
+		m.warmer.Stop()
+	}
 	if m.syncWorker != nil {
 		m.logger.Info("stopping certificate sync worker")
 		m.syncWorker.Stop(10 * time.Second)

--- a/tlsmanager/storage/fallback_cache.go
+++ b/tlsmanager/storage/fallback_cache.go
@@ -16,25 +16,44 @@ import (
 	"golang.org/x/crypto/acme/autocert"
 )
 
-// certNotAfter parses a PEM cert+key bundle (as stored by autocert) and returns
-// the leaf certificate's expiry. ok is false when the data holds no parseable
-// certificate (e.g. account keys or challenge tokens).
-func certNotAfter(pemData []byte) (t time.Time, ok bool) {
+// certValidity parses a PEM cert+key bundle (as stored by autocert) and returns
+// the leaf certificate's validity window. ok is false when the data holds no
+// parseable certificate (e.g. account keys or challenge tokens).
+func certValidity(pemData []byte) (notBefore, notAfter time.Time, ok bool) {
 	rest := pemData
 	for {
 		var block *pem.Block
 		block, rest = pem.Decode(rest)
 		if block == nil {
-			return time.Time{}, false
+			return time.Time{}, time.Time{}, false
 		}
 		if block.Type == "CERTIFICATE" {
 			cert, err := x509.ParseCertificate(block.Bytes)
 			if err != nil {
-				return time.Time{}, false
+				return time.Time{}, time.Time{}, false
 			}
-			return cert.NotAfter, true
+			return cert.NotBefore, cert.NotAfter, true
 		}
 	}
+}
+
+// certNotAfter parses a PEM cert+key bundle (as stored by autocert) and returns
+// the leaf certificate's expiry. ok is false when the data holds no parseable
+// certificate (e.g. account keys or challenge tokens).
+func certNotAfter(pemData []byte) (t time.Time, ok bool) {
+	_, notAfter, ok := certValidity(pemData)
+	return notAfter, ok
+}
+
+// renewalThreshold mirrors autocert's renewal window: min(lifetime/3, 30 days)
+// before expiry (see acme/autocert/renewal.go). A cert inside this window is
+// one the leader may already have renewed, so followers re-check S3 for it.
+func renewalThreshold(notBefore, notAfter time.Time) time.Duration {
+	threshold := notAfter.Sub(notBefore) / 3
+	if maxThreshold := 30 * 24 * time.Hour; threshold > maxThreshold {
+		threshold = maxThreshold
+	}
+	return threshold
 }
 
 // isChallengeToken reports whether an autocert cache key is an ephemeral ACME
@@ -66,7 +85,34 @@ type FallbackCache struct {
 	lastS3Check      time.Time     // When did we last check S3?
 	checkInterval    time.Duration // How often to retry S3 after failure (default 30s)
 	consecutiveFails int           // Consecutive S3 failure count (protected by s3Mu)
+
+	// Freshness revalidation: when a locally cached cert is inside its renewal
+	// window, Get re-checks S3 (throttled per key) and adopts a newer cert if
+	// the cluster leader has renewed it. This is the deterministic replacement
+	// for push-invalidation: it converges within revalidateEvery of a leader
+	// renewal, weeks before the old cert expires.
+	revalMu         sync.Mutex           // Protects lastRevalidate
+	lastRevalidate  map[string]time.Time // Per-key last S3 revalidation attempt
+	revalidateEvery time.Duration        // Min interval between per-key revalidations (default 1h)
+
+	// Challenge-token read throttle: token Gets are S3-only (see Get), and an
+	// unauthenticated tls-alpn-01 ClientHello would otherwise amplify 1:1
+	// into billable S3 GETs. Results (hits AND misses) are reused for a
+	// second; real CA validation probes arrive well after the token is
+	// published, so the added staleness is negligible.
+	tokenMu      sync.Mutex
+	tokenResults map[string]tokenResult
 }
+
+// tokenResult is a briefly cached challenge-token read result.
+type tokenResult struct {
+	data []byte
+	err  error
+	at   time.Time
+}
+
+// tokenResultTTL bounds S3 reads per token key to ~1/second.
+const tokenResultTTL = time.Second
 
 // NewFallbackCache creates a new two-tier cache with S3 as primary.
 // Returns S3-only cache with a warning if fallback directory cannot be created.
@@ -81,13 +127,35 @@ func NewFallbackCache(localDir string, s3Cache *S3Cache, logger *slog.Logger) *F
 	}
 
 	return &FallbackCache{
-		primary:       s3Cache,                     // S3 is source of truth
-		fallback:      autocert.DirCache(localDir), // Local is cache for speed
-		fallbackDir:   localDir,
-		logger:        logger,
-		s3Available:   true,             // Assume S3 is available initially
-		checkInterval: 30 * time.Second, // Retry S3 after 30s on failure
+		primary:         s3Cache,                     // S3 is source of truth
+		fallback:        autocert.DirCache(localDir), // Local is cache for speed
+		fallbackDir:     localDir,
+		logger:          logger,
+		s3Available:     true,             // Assume S3 is available initially
+		checkInterval:   30 * time.Second, // Retry S3 after 30s on failure
+		lastRevalidate:  make(map[string]time.Time),
+		revalidateEvery: time.Hour,
+		tokenResults:    make(map[string]tokenResult),
 	}
+}
+
+// S3Healthy reports whether an S3 operation is currently worth attempting.
+// Callers such as the cert warmer use this to defer ACME issuance while
+// certificates cannot be replicated to the cluster. This deliberately shares
+// isS3Available's retry-window semantics: after checkInterval it reports true
+// again so callers probe S3 rather than staying suppressed forever — the
+// breaker state itself only flips back on an actual successful operation,
+// which on a quiet node might otherwise never happen.
+func (f *FallbackCache) S3Healthy() bool {
+	return f.isS3Available()
+}
+
+// SetRetryInterval adjusts how long the circuit breaker waits before letting
+// S3 operations be retried after a failure.
+func (f *FallbackCache) SetRetryInterval(d time.Duration) {
+	f.s3Mu.Lock()
+	defer f.s3Mu.Unlock()
+	f.checkInterval = d
 }
 
 // isS3Available checks if S3 should be tried based on recent failures.
@@ -151,14 +219,23 @@ func (f *FallbackCache) markS3Available() {
 // Get retrieves a certificate, trying local cache first (fast), then S3 (slow).
 // This ensures TLS handshakes are fast when certificates are already cached locally.
 // S3 operations have a 5-second timeout to prevent blocking TLS handshakes.
+//
+// Challenge tokens bypass the local tier entirely: the tls-alpn-01 key
+// ("domain+token") is FIXED per domain, so a local copy cached during one
+// validation would shadow the fresh token the leader writes at the next
+// renewal, permanently breaking cross-node ALPN validation.
 func (f *FallbackCache) Get(ctx context.Context, key string) ([]byte, error) {
+	if isChallengeToken(key) {
+		return f.getChallengeToken(ctx, key)
+	}
+
 	f.logger.Debug("FallbackCache: Get certificate (checking local cache first)", "name", key)
 
 	// STEP 1: Try local cache first (FAST - no network call)
 	data, err := f.fallback.Get(ctx, key)
 	if err == nil {
 		f.logger.Debug("FallbackCache: certificate found in local cache", "name", key)
-		return data, nil
+		return f.maybeRevalidate(ctx, key, data), nil
 	}
 
 	// Not in local cache or error reading
@@ -219,9 +296,188 @@ func (f *FallbackCache) Get(ctx context.Context, key string) ([]byte, error) {
 	return nil, autocert.ErrCacheMiss
 }
 
+// getChallengeToken reads an ACME challenge token from S3 only. Tokens are
+// written seconds before Let's Encrypt validates and deleted right after, so
+// the local tier is never authoritative for them (see Get for why caching the
+// fixed "domain+token" key locally is actively harmful). Results are reused
+// for tokenResultTTL to keep unauthenticated probes from amplifying into
+// unbounded S3 reads.
+func (f *FallbackCache) getChallengeToken(ctx context.Context, key string) ([]byte, error) {
+	f.tokenMu.Lock()
+	if r, ok := f.tokenResults[key]; ok && time.Since(r.at) < tokenResultTTL {
+		f.tokenMu.Unlock()
+		return r.data, r.err
+	}
+	// Claim the slot before releasing the lock so concurrent probes for the
+	// same key reuse this read's outcome instead of racing to S3.
+	f.tokenResults[key] = tokenResult{err: autocert.ErrCacheMiss, at: time.Now()}
+	f.tokenMu.Unlock()
+
+	data, err := f.fetchChallengeToken(ctx, key)
+
+	f.tokenMu.Lock()
+	f.tokenResults[key] = tokenResult{data: data, err: err, at: time.Now()}
+	// Drop stale entries so the map stays bounded by recently probed keys.
+	for k, r := range f.tokenResults {
+		if time.Since(r.at) >= tokenResultTTL {
+			delete(f.tokenResults, k)
+		}
+	}
+	f.tokenMu.Unlock()
+
+	return data, err
+}
+
+func (f *FallbackCache) fetchChallengeToken(ctx context.Context, key string) ([]byte, error) {
+	if !f.isS3Available() {
+		f.logger.Warn("FallbackCache: S3 unavailable (circuit breaker), cannot serve challenge token", "name", key)
+		return nil, autocert.ErrCacheMiss
+	}
+
+	s3Ctx, s3Cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer s3Cancel()
+
+	data, err := f.primary.Get(s3Ctx, key)
+	if err == nil {
+		f.markS3Available()
+		return data, nil
+	}
+	if err == autocert.ErrCacheMiss {
+		return nil, autocert.ErrCacheMiss
+	}
+	f.logger.Warn("FallbackCache: S3 Get failed for challenge token", "name", key, "error", err)
+	f.markS3Unavailable()
+	return nil, autocert.ErrCacheMiss
+}
+
+// maybeRevalidate returns the freshest available bundle for a locally cached
+// certificate. When the local cert is inside its renewal window (the only
+// period during which the cluster leader may have published a newer cert to
+// S3), it re-checks S3 at most once per revalidateEvery per key and adopts the
+// S3 copy if its expiry is later. Outside the window, or on any S3 problem, the
+// local copy is returned unchanged — this path must never fail a handshake that
+// the local cert could serve.
+func (f *FallbackCache) maybeRevalidate(ctx context.Context, key string, local []byte) []byte {
+	notBefore, notAfter, ok := certValidity(local)
+	if !ok {
+		// Not a certificate bundle (account key etc.) — nothing to revalidate.
+		return local
+	}
+	if time.Until(notAfter) >= renewalThreshold(notBefore, notAfter) {
+		return local // Not yet in the renewal window; leader cannot have renewed.
+	}
+
+	// Check the breaker BEFORE consuming the hourly revalidation slot: a
+	// throttle stamp recorded while S3 is unreachable would suppress the
+	// actual revalidation for a full revalidateEvery after S3 recovers.
+	if !f.isS3Available() {
+		return local
+	}
+
+	f.revalMu.Lock()
+	last, seen := f.lastRevalidate[key]
+	if seen && time.Since(last) < f.revalidateEvery {
+		f.revalMu.Unlock()
+		return local
+	}
+	f.lastRevalidate[key] = time.Now()
+	f.revalMu.Unlock()
+
+	s3Ctx, s3Cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer s3Cancel()
+
+	s3Data, err := f.primary.Get(s3Ctx, key)
+	if err != nil {
+		if err != autocert.ErrCacheMiss {
+			f.logger.Warn("FallbackCache: S3 revalidation failed - serving local certificate", "name", key, "error", err)
+			f.markS3Unavailable()
+		}
+		return local
+	}
+	f.markS3Available()
+
+	s3NotAfter, ok := certNotAfter(s3Data)
+	if !ok || !s3NotAfter.After(notAfter) {
+		return local // S3 copy is not newer.
+	}
+
+	// Fetch-then-swap: persist the newer cert locally BEFORE serving it, so a
+	// crash between the two cannot leave the local tier ahead of what we return.
+	f.logger.Info("FallbackCache: adopted renewed certificate from S3",
+		"name", key, "local_expiry", notAfter, "s3_expiry", s3NotAfter)
+	if putErr := f.fallback.Put(ctx, key, s3Data); putErr != nil {
+		f.logger.Warn("FallbackCache: failed to persist renewed certificate locally", "name", key, "error", putErr)
+	}
+	return s3Data
+}
+
+// RefreshFromS3 bypasses the local tier and fetches a key directly from S3,
+// persisting it locally on success. Cluster followers use this on a hard local
+// miss to pick up a certificate the leader has just published; the plain Get
+// path cannot serve this case because it prefers the local copy.
+func (f *FallbackCache) RefreshFromS3(ctx context.Context, key string) ([]byte, error) {
+	if !f.isS3Available() {
+		return nil, autocert.ErrCacheMiss
+	}
+
+	s3Ctx, s3Cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer s3Cancel()
+
+	data, err := f.primary.Get(s3Ctx, key)
+	if err != nil {
+		if err != autocert.ErrCacheMiss {
+			f.logger.Warn("FallbackCache: RefreshFromS3 failed", "name", key, "error", err)
+			f.markS3Unavailable()
+		}
+		return nil, autocert.ErrCacheMiss
+	}
+	f.markS3Available()
+
+	if !isChallengeToken(key) {
+		if putErr := f.fallback.Put(ctx, key, data); putErr != nil {
+			f.logger.Warn("FallbackCache: failed to persist refreshed certificate locally", "name", key, "error", putErr)
+		}
+	}
+	return data, nil
+}
+
 // Put stores a certificate, trying S3 first (source of truth), then falling back to local cache.
 // Matches mizu architecture: S3 is primary storage, local is fallback for resilience.
+//
+// Challenge tokens go to S3 only: they exist so that OTHER nodes can serve the
+// validation, a local-only copy is useless for that, and a stale local copy
+// under the fixed "domain+token" key breaks future validations.
+//
+// NOTE: autocert IGNORES errors from challenge-token Puts (putHTTPToken and
+// putCertToken) — a failed publish does not abort or defer the ACME flow; the
+// issuance proceeds with the token held only in the issuing node's memory, and
+// validation then succeeds only if the CA's probe happens to land on this
+// node. The error return and the loud log below are the observable signal; the
+// cert warmer additionally defers whole warm passes while S3 is unhealthy to
+// shrink this window.
 func (f *FallbackCache) Put(ctx context.Context, key string, data []byte) error {
+	if isChallengeToken(key) {
+		// A fresh token supersedes any briefly cached read result for its key
+		// (a miss cached moments before this publish must not be served to
+		// the CA's validation probe).
+		defer func() {
+			f.tokenMu.Lock()
+			delete(f.tokenResults, key)
+			f.tokenMu.Unlock()
+		}()
+
+		if !f.isS3Available() {
+			return fmt.Errorf("S3 unavailable - cannot publish challenge token %q for cluster-wide validation", key)
+		}
+		if err := f.primary.Put(ctx, key, data); err != nil {
+			f.logger.Warn("FallbackCache: failed to publish challenge token to S3 - validation may fail", "name", key, "error", err)
+			f.markS3Unavailable()
+			return err
+		}
+		f.markS3Available()
+		return nil
+	}
+
 	var s3Err error
 
 	// Try S3 first if available (source of truth)
@@ -292,6 +548,8 @@ func (f *FallbackCache) syncToS3(key string, data []byte) {
 }
 
 // Delete removes a certificate from both S3 and fallback cache.
+// For challenge tokens the local delete also covers legacy copies cached by
+// earlier versions that still wrote tokens to the local tier.
 func (f *FallbackCache) Delete(ctx context.Context, key string) error {
 	var s3Err error
 

--- a/tlsmanager/storage/fallback_cache_test.go
+++ b/tlsmanager/storage/fallback_cache_test.go
@@ -156,3 +156,347 @@ func TestCertNotAfter(t *testing.T) {
 		t.Error("certNotAfter should return ok=false for non-certificate data")
 	}
 }
+
+// makeCertPEMWindow creates a cert PEM with an explicit validity window, for
+// exercising the renewal-window revalidation logic.
+func makeCertPEMWindow(t *testing.T, notBefore, notAfter time.Time) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "example.com"},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return buf.Bytes()
+}
+
+func TestRenewalThreshold(t *testing.T) {
+	base := time.Now()
+	// 90-day cert: lifetime/3 = 30d, capped at 30d.
+	if got := renewalThreshold(base, base.Add(90*24*time.Hour)); got != 30*24*time.Hour {
+		t.Errorf("90d cert: threshold = %v, want 30d", got)
+	}
+	// 9-day cert: lifetime/3 = 3d.
+	if got := renewalThreshold(base, base.Add(9*24*time.Hour)); got != 3*24*time.Hour {
+		t.Errorf("9d cert: threshold = %v, want 3d", got)
+	}
+	// 180-day cert: capped at 30d.
+	if got := renewalThreshold(base, base.Add(180*24*time.Hour)); got != 30*24*time.Hour {
+		t.Errorf("180d cert: threshold = %v, want 30d cap", got)
+	}
+}
+
+// TestGet_ChallengeTokenBypassesLocalTier verifies challenge tokens are read
+// from S3 only: the tls-alpn-01 key is fixed per domain, so a stale local copy
+// must never shadow the fresh token the leader published for a new validation.
+func TestGet_ChallengeTokenBypassesLocalTier(t *testing.T) {
+	fc, _ := newTestFallbackCache(t)
+	ctx := context.Background()
+	const key = "example.com+token"
+
+	stale := []byte("stale-token-cert")
+	fresh := []byte("fresh-token-cert")
+	if err := fc.fallback.Put(ctx, key, stale); err != nil {
+		t.Fatal(err)
+	}
+	if err := fc.primary.Put(ctx, key, fresh); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fc.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, fresh) {
+		t.Error("challenge token Get must return the S3 copy, not the stale local copy")
+	}
+
+	// Token present ONLY locally must be a miss: local is never authoritative.
+	const localOnly = "orphan+http-01"
+	if err := fc.fallback.Put(ctx, localOnly, stale); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fc.Get(ctx, localOnly); err != autocert.ErrCacheMiss {
+		t.Errorf("local-only token should be ErrCacheMiss, got %v", err)
+	}
+}
+
+// TestPut_ChallengeTokenGoesToS3Only verifies tokens are published to S3 for
+// cluster-wide validation and never cached locally.
+func TestPut_ChallengeTokenGoesToS3Only(t *testing.T) {
+	fc, mock := newTestFallbackCache(t)
+	ctx := context.Background()
+	const key = "example.com+token"
+
+	if err := fc.Put(ctx, key, []byte("token-cert")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if _, err := fc.primary.Get(ctx, key); err != nil {
+		t.Errorf("token should be in S3, got %v", err)
+	}
+	if _, err := fc.fallback.Get(ctx, key); err != autocert.ErrCacheMiss {
+		t.Errorf("token must NOT be written to the local tier, got %v", err)
+	}
+
+	// With S3 down the Put must fail loudly (issuance deferred), not silently
+	// strand the token on the local disk while Let's Encrypt validates.
+	mock.PutErr = errors.New("s3 down")
+	if err := fc.Put(ctx, "tok2+http-01", []byte("x")); err == nil {
+		t.Error("token Put with S3 down should return an error")
+	}
+	if _, err := fc.fallback.Get(ctx, "tok2+http-01"); err != autocert.ErrCacheMiss {
+		t.Error("failed token Put must not fall back to local storage")
+	}
+}
+
+// TestGet_AdoptsRenewedCertInRenewalWindow verifies the freshness path: a local
+// cert inside its renewal window triggers an S3 re-check, and a newer S3 cert
+// (published by the cluster leader) is adopted and persisted locally.
+func TestGet_AdoptsRenewedCertInRenewalWindow(t *testing.T) {
+	fc, _ := newTestFallbackCache(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	// Lifetime 80d, 20d until expiry, threshold min(80/3, 30)=26.6d -> in window.
+	local := makeCertPEMWindow(t, now.Add(-60*24*time.Hour), now.Add(20*24*time.Hour))
+	renewed := makeCertPEMWindow(t, now.Add(-24*time.Hour), now.Add(89*24*time.Hour))
+
+	if err := fc.fallback.Put(ctx, "example.com", local); err != nil {
+		t.Fatal(err)
+	}
+	if err := fc.primary.Put(ctx, "example.com", renewed); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fc.Get(ctx, "example.com")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, renewed) {
+		t.Error("Get should adopt the renewed cert from S3 when local is in the renewal window")
+	}
+	localGot, _ := fc.fallback.Get(ctx, "example.com")
+	if !bytes.Equal(localGot, renewed) {
+		t.Error("adopted cert should be persisted to the local tier")
+	}
+}
+
+// TestGet_NoRevalidationOutsideRenewalWindow verifies zero S3 traffic (and no
+// adoption) while the local cert is far from expiry.
+func TestGet_NoRevalidationOutsideRenewalWindow(t *testing.T) {
+	fc, _ := newTestFallbackCache(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	// Lifetime 81d, 80d until expiry, threshold 27d -> NOT in window.
+	local := makeCertPEMWindow(t, now.Add(-24*time.Hour), now.Add(80*24*time.Hour))
+	other := makeCertPEMWindow(t, now, now.Add(120*24*time.Hour))
+
+	if err := fc.fallback.Put(ctx, "example.com", local); err != nil {
+		t.Fatal(err)
+	}
+	if err := fc.primary.Put(ctx, "example.com", other); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fc.Get(ctx, "example.com")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, local) {
+		t.Error("Get must serve the local cert unchanged outside the renewal window")
+	}
+}
+
+// TestGet_RevalidationThrottled verifies at most one S3 re-check per
+// revalidateEvery per key, and that the throttle expiring re-enables adoption.
+func TestGet_RevalidationThrottled(t *testing.T) {
+	fc, _ := newTestFallbackCache(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	local := makeCertPEMWindow(t, now.Add(-60*24*time.Hour), now.Add(20*24*time.Hour))
+	// Newer but still inside the renewal window (25d left of a 125d lifetime).
+	renewed1 := makeCertPEMWindow(t, now.Add(-100*24*time.Hour), now.Add(25*24*time.Hour))
+	renewed2 := makeCertPEMWindow(t, now, now.Add(150*24*time.Hour))
+
+	if err := fc.fallback.Put(ctx, "example.com", local); err != nil {
+		t.Fatal(err)
+	}
+	if err := fc.primary.Put(ctx, "example.com", renewed1); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, _ := fc.Get(ctx, "example.com"); !bytes.Equal(got, renewed1) {
+		t.Fatal("first Get should adopt renewed1")
+	}
+
+	// S3 has an even newer cert, but the throttle window has not elapsed.
+	if err := fc.primary.Put(ctx, "example.com", renewed2); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := fc.Get(ctx, "example.com"); !bytes.Equal(got, renewed1) {
+		t.Error("second Get within revalidateEvery should be throttled and serve the local copy")
+	}
+
+	// Expire the throttle: adoption resumes.
+	fc.revalMu.Lock()
+	fc.lastRevalidate["example.com"] = time.Now().Add(-2 * fc.revalidateEvery)
+	fc.revalMu.Unlock()
+	if got, _ := fc.Get(ctx, "example.com"); !bytes.Equal(got, renewed2) {
+		t.Error("Get after throttle expiry should adopt renewed2")
+	}
+}
+
+// TestGet_RevalidationS3ErrorServesLocal verifies the freshness check can never
+// fail a handshake the local cert could serve.
+func TestGet_RevalidationS3ErrorServesLocal(t *testing.T) {
+	fc, mock := newTestFallbackCache(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	local := makeCertPEMWindow(t, now.Add(-60*24*time.Hour), now.Add(20*24*time.Hour))
+	if err := fc.fallback.Put(ctx, "example.com", local); err != nil {
+		t.Fatal(err)
+	}
+	mock.GetErr = errors.New("s3 down")
+
+	got, err := fc.Get(ctx, "example.com")
+	if err != nil {
+		t.Fatalf("Get must not fail when revalidation cannot reach S3: %v", err)
+	}
+	if !bytes.Equal(got, local) {
+		t.Error("Get should serve the local cert when S3 is unreachable")
+	}
+}
+
+// TestRefreshFromS3 verifies the follower hard-miss path: S3 is consulted
+// directly (bypassing the local-first order) and the result persisted locally.
+func TestRefreshFromS3(t *testing.T) {
+	fc, mock := newTestFallbackCache(t)
+	ctx := context.Background()
+
+	cert := makeCertPEM(t, time.Now().Add(80*24*time.Hour))
+	if err := fc.primary.Put(ctx, "example.com", cert); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fc.RefreshFromS3(ctx, "example.com")
+	if err != nil {
+		t.Fatalf("RefreshFromS3: %v", err)
+	}
+	if !bytes.Equal(got, cert) {
+		t.Error("RefreshFromS3 should return the S3 copy")
+	}
+	if localGot, _ := fc.fallback.Get(ctx, "example.com"); !bytes.Equal(localGot, cert) {
+		t.Error("RefreshFromS3 should persist the cert locally")
+	}
+
+	mock.GetErr = errors.New("s3 down")
+	if _, err := fc.RefreshFromS3(ctx, "other.example.com"); err != autocert.ErrCacheMiss {
+		t.Errorf("RefreshFromS3 on S3 error should be ErrCacheMiss, got %v", err)
+	}
+}
+
+func TestS3Healthy(t *testing.T) {
+	fc, _ := newTestFallbackCache(t)
+	if !fc.S3Healthy() {
+		t.Error("S3 should be considered healthy initially")
+	}
+	fc.markS3Unavailable()
+	if fc.S3Healthy() {
+		t.Error("S3 should be unhealthy right after a failure")
+	}
+	// Retry-window semantics: once checkInterval elapses, S3Healthy must
+	// report true again so callers (the warmer) probe S3 instead of staying
+	// suppressed forever — the breaker only flips back on a successful op,
+	// which a quiet node might never perform otherwise.
+	fc.SetRetryInterval(0)
+	if !fc.S3Healthy() {
+		t.Error("S3Healthy should report true again after the retry interval elapses")
+	}
+	fc.SetRetryInterval(30 * time.Second)
+	fc.markS3Unavailable()
+	fc.markS3Available()
+	if !fc.S3Healthy() {
+		t.Error("S3 should be healthy again after recovery")
+	}
+}
+
+// TestGet_RevalidationSlotNotBurnedWhileBreakerOpen verifies an in-window Get
+// during an S3 outage does not consume the hourly revalidation slot: the
+// adoption must happen promptly once S3 recovers.
+func TestGet_RevalidationSlotNotBurnedWhileBreakerOpen(t *testing.T) {
+	fc, mock := newTestFallbackCache(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	local := makeCertPEMWindow(t, now.Add(-60*24*time.Hour), now.Add(20*24*time.Hour))
+	renewed := makeCertPEMWindow(t, now.Add(-24*time.Hour), now.Add(89*24*time.Hour))
+	if err := fc.fallback.Put(ctx, "example.com", local); err != nil {
+		t.Fatal(err)
+	}
+	if err := fc.primary.Put(ctx, "example.com", renewed); err != nil {
+		t.Fatal(err)
+	}
+
+	// Open the breaker, then Get: serves local WITHOUT consuming the slot.
+	fc.markS3Unavailable()
+	if got, _ := fc.Get(ctx, "example.com"); !bytes.Equal(got, local) {
+		t.Fatal("breaker-open Get should serve the local cert")
+	}
+	fc.revalMu.Lock()
+	_, burned := fc.lastRevalidate["example.com"]
+	fc.revalMu.Unlock()
+	if burned {
+		t.Error("revalidation slot must not be consumed while the breaker is open")
+	}
+
+	// S3 recovers: the very next Get adopts the renewed cert.
+	fc.markS3Available()
+	if got, _ := fc.Get(ctx, "example.com"); !bytes.Equal(got, renewed) {
+		t.Error("first Get after S3 recovery should adopt the renewed cert")
+	}
+	_ = mock
+}
+
+// TestGetChallengeToken_ThrottlesS3Reads verifies token reads are reused for
+// tokenResultTTL (unauthenticated ALPN probes must not amplify 1:1 into S3
+// GETs) and that publishing a token invalidates a cached miss.
+func TestGetChallengeToken_ThrottlesS3Reads(t *testing.T) {
+	fc, mock := newTestFallbackCache(t)
+	ctx := context.Background()
+	const key = "example.com+token"
+
+	// Two probes for a missing token: only one S3 read.
+	if _, err := fc.Get(ctx, key); err != autocert.ErrCacheMiss {
+		t.Fatalf("expected miss, got %v", err)
+	}
+	first := mock.GetCalls
+	if _, err := fc.Get(ctx, key); err != autocert.ErrCacheMiss {
+		t.Fatalf("expected miss, got %v", err)
+	}
+	if mock.GetCalls != first {
+		t.Errorf("second probe within tokenResultTTL should not hit S3 (calls %d -> %d)", first, mock.GetCalls)
+	}
+
+	// Publishing the token must invalidate the cached miss immediately: the
+	// CA's validation probe may arrive well within tokenResultTTL.
+	if err := fc.Put(ctx, key, []byte("fresh-token")); err != nil {
+		t.Fatal(err)
+	}
+	got, err := fc.Get(ctx, key)
+	if err != nil || !bytes.Equal(got, []byte("fresh-token")) {
+		t.Errorf("probe after publish must see the fresh token, got %q err=%v", got, err)
+	}
+}

--- a/tlsmanager/storage/mock_s3.go
+++ b/tlsmanager/storage/mock_s3.go
@@ -12,10 +12,11 @@ import (
 // MockS3Client implements the S3 operations needed for testing
 // It uses an in-memory map to store data
 type MockS3Client struct {
-	Storage map[string][]byte
-	GetErr  error
-	PutErr  error
-	DelErr  error
+	Storage  map[string][]byte
+	GetErr   error
+	PutErr   error
+	DelErr   error
+	GetCalls int // Number of GetObject invocations
 }
 
 // NewMockS3Client creates a new mock S3 client with empty storage
@@ -26,6 +27,7 @@ func NewMockS3Client() *MockS3Client {
 }
 
 func (m *MockS3Client) GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	m.GetCalls++
 	if m.GetErr != nil {
 		return nil, m.GetErr
 	}

--- a/tlsmanager/warmer.go
+++ b/tlsmanager/warmer.go
@@ -1,0 +1,268 @@
+package tlsmanager
+
+import (
+	"context"
+	"crypto/tls"
+	"math/rand/v2"
+	"sync"
+	"time"
+)
+
+const (
+	// warmerInitialDelayMin/Max: jittered startup delay. At fleet boot every
+	// node briefly considers itself cluster leader until memberlist join
+	// converges (initial Join is best-effort and the rejoin loop retries every
+	// 30s), so warming immediately would make N nodes bulk-issue all domains
+	// against Let's Encrypt simultaneously. By 60-120s only the real leader
+	// still passes the leadership check.
+	warmerInitialDelayMin = 60 * time.Second
+	warmerInitialDelayMax = 120 * time.Second
+
+	// warmerInterval is the cadence of periodic warm passes. autocert serves
+	// still-valid certs from cache without touching ACME, so passes outside
+	// the renewal window are cheap no-issuance checks.
+	warmerInterval = 12 * time.Hour
+
+	// warmerLeaderPoll is how often leadership is re-checked between passes so
+	// a newly promoted leader converges quickly instead of waiting for the
+	// next 12h tick (followers hold no warm state).
+	warmerLeaderPoll = 15 * time.Second
+
+	// warmerMinPassGap bounds how often warm passes may run regardless of the
+	// trigger (tick, promotion). Combined with one attempt per domain per
+	// pass, this keeps ACME failure retries far below Let's Encrypt's
+	// 5-failed-validations/hour limit even under leadership flapping.
+	warmerMinPassGap = 15 * time.Minute
+
+	// warmerDomainGap spaces per-domain issuance attempts within a pass.
+	warmerDomainGap = 2 * time.Second
+)
+
+// certWarmer proactively obtains and renews certificates for all configured
+// domains on the cluster leader (or the sole node in single-instance mode).
+// This keeps the shared certificate store populated independent of which node
+// receives traffic, so followers essentially never encounter a domain the
+// leader has not already issued for, and renewal happens on the leader's
+// schedule rather than opportunistically on whichever node a handshake lands.
+type certWarmer struct {
+	m       *Manager
+	domains []string
+	warmRSA bool
+
+	mu       sync.Mutex
+	lastPass time.Time
+	pending  bool // A pass was deferred (S3 unhealthy) and should be retried
+
+	stopCh   chan struct{}
+	doneCh   chan struct{}
+	stopOnce sync.Once
+}
+
+func newCertWarmer(m *Manager, domains []string, warmRSA bool) *certWarmer {
+	return &certWarmer{
+		m:       m,
+		domains: domains,
+		warmRSA: warmRSA,
+		stopCh:  make(chan struct{}),
+		doneCh:  make(chan struct{}),
+	}
+}
+
+// Start launches the warmer loop in a background goroutine.
+func (w *certWarmer) Start() {
+	go w.run()
+}
+
+// Stop terminates the warmer loop and waits briefly for it to exit.
+func (w *certWarmer) Stop() {
+	w.stopOnce.Do(func() { close(w.stopCh) })
+	select {
+	case <-w.doneCh:
+	case <-time.After(5 * time.Second):
+		w.m.logger.Warn("cert warmer stop timed out")
+	}
+}
+
+func (w *certWarmer) run() {
+	defer close(w.doneCh)
+	defer func() {
+		if r := recover(); r != nil {
+			w.m.logger.Error("panic in cert warmer", "panic", r)
+		}
+	}()
+
+	delay := warmerInitialDelayMin +
+		time.Duration(rand.Int64N(int64(warmerInitialDelayMax-warmerInitialDelayMin)))
+	select {
+	case <-time.After(delay):
+	case <-w.stopCh:
+		return
+	}
+
+	w.maybeWarm()
+
+	ticker := time.NewTicker(warmerInterval)
+	defer ticker.Stop()
+	leaderPoll := time.NewTicker(warmerLeaderPoll)
+	defer leaderPoll.Stop()
+
+	wasLeader := w.isLeader()
+	for {
+		select {
+		case <-ticker.C:
+			w.maybeWarm()
+		case <-leaderPoll.C:
+			is := w.isLeader()
+			if is && !wasLeader {
+				// Leadership acquired (leader restart or handover): converge
+				// immediately so the cluster is not left without an issuer.
+				w.m.logger.Info("cert warmer: leadership acquired - running warm pass")
+				w.maybeWarm()
+			} else if is && w.isPending() {
+				// A pass was deferred while S3 was unhealthy: retry it now
+				// instead of waiting for the 12h ticker. maybeWarm re-checks
+				// S3 health, so this stays a cheap no-op until S3 is worth
+				// probing again.
+				w.maybeWarm()
+			}
+			wasLeader = is
+		case <-w.stopCh:
+			return
+		}
+	}
+}
+
+// isLeader reports whether this node should warm certificates. With no cluster
+// leadership wired (single-instance mode) the answer is always yes: proactive
+// renewal is just as valuable there, replacing renewal that would otherwise
+// only be triggered by client handshakes.
+func (w *certWarmer) isLeader() bool {
+	if w.m.isLeader == nil {
+		return true
+	}
+	return w.m.isLeader()
+}
+
+// isPending reports whether a warm pass was deferred and awaits retry.
+func (w *certWarmer) isPending() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.pending
+}
+
+func (w *certWarmer) maybeWarm() {
+	if !w.isLeader() {
+		return
+	}
+
+	w.mu.Lock()
+	if time.Since(w.lastPass) < warmerMinPassGap {
+		w.mu.Unlock()
+		return
+	}
+	w.mu.Unlock()
+
+	// Defer issuance while S3 is unreachable: a cert (or challenge token) that
+	// cannot be replicated to the shared store does not help the cluster, and
+	// challenge validation may land on another node that reads from S3. The
+	// deferral does NOT consume the pass budget (lastPass) — the pending flag
+	// makes the leadership poll retry as soon as S3 is worth probing again,
+	// rather than silently waiting for the next 12h tick.
+	if fc := w.m.fallbackCache; fc != nil && !fc.S3Healthy() {
+		w.m.logger.Warn("cert warmer: S3 unavailable - deferring warm pass")
+		w.mu.Lock()
+		w.pending = true
+		w.mu.Unlock()
+		return
+	}
+
+	w.mu.Lock()
+	w.lastPass = time.Now()
+	w.pending = false
+	w.mu.Unlock()
+
+	w.m.logger.Debug("cert warmer: starting warm pass", "domains", len(w.domains))
+	for i, domain := range w.domains {
+		// Re-check leadership before EACH domain: leadership can move
+		// mid-pass (e.g. the lexicographically smallest node rejoining) and
+		// two nodes warming concurrently is exactly the duplicate-issuance
+		// this component exists to prevent.
+		if !w.isLeader() {
+			w.m.logger.Info("cert warmer: lost leadership mid-pass - stopping", "completed", i, "total", len(w.domains))
+			return
+		}
+		w.warmDomain(domain)
+
+		select {
+		case <-time.After(warmerDomainGap):
+		case <-w.stopCh:
+			return
+		}
+	}
+	w.m.logger.Debug("cert warmer: warm pass complete", "domains", len(w.domains))
+
+	// Repair pass: push any certificates that exist only locally back to S3
+	// (e.g. a wiped or hollowed store). autocert's cert() is state-first, so
+	// a leader whose certs live in memory and on local disk would otherwise
+	// never re-publish them, leaving followers with nothing to read. It also
+	// adopts newer S3 certs locally and cleans orphaned challenge tokens.
+	if fc := w.m.fallbackCache; fc != nil {
+		syncCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		if err := fc.SyncAllToS3(syncCtx); err != nil {
+			w.m.logger.Warn("cert warmer: store repair sync failed", "error", err)
+		}
+		cancel()
+	}
+}
+
+func (w *certWarmer) warmDomain(domain string) {
+	// ECDSA first: it is the flavor modern clients request (autocert keys the
+	// cache by flavor — plain "domain" for ECDSA, "domain+rsa" for legacy).
+	// A bare ClientHelloInfo would fail autocert's supportsECDSA check and
+	// issue only the RSA variant that real handshakes never read.
+	flavors := []struct {
+		name  string
+		hello *tls.ClientHelloInfo
+	}{
+		{"ecdsa", warmECDSAHello(domain)},
+	}
+	if w.warmRSA {
+		flavors = append(flavors, struct {
+			name  string
+			hello *tls.ClientHelloInfo
+		}{"rsa", warmRSAHello(domain)})
+	}
+
+	for _, f := range flavors {
+		// Call the autocert manager directly rather than the wrapped
+		// GetCertificate: the wrapper's SNI-default and cluster-gating logic
+		// is for real handshakes. autocert manages its own timeout context;
+		// still-valid cached certs return without touching ACME, and failures
+		// are not retried until the next pass (>= warmerMinPassGap away).
+		if _, err := w.m.autocertManager.GetCertificate(f.hello); err != nil {
+			w.m.logger.Error("cert warmer: failed to obtain certificate",
+				"domain", domain, "flavor", f.name, "error", err)
+		}
+	}
+}
+
+// warmECDSAHello builds a synthetic ClientHello that autocert's supportsECDSA
+// resolves to the default ECDSA flavor (cache key "domain"): the signature
+// scheme, curve, and cipher-suite checks must all pass.
+func warmECDSAHello(domain string) *tls.ClientHelloInfo {
+	return &tls.ClientHelloInfo{
+		ServerName:       domain,
+		CipherSuites:     []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
+		SupportedCurves:  []tls.CurveID{tls.CurveP256},
+		SignatureSchemes: []tls.SignatureScheme{tls.ECDSAWithP256AndSHA256},
+	}
+}
+
+// warmRSAHello builds a synthetic ClientHello with no ECDSA capability, which
+// autocert resolves to the legacy RSA flavor (cache key "domain+rsa").
+func warmRSAHello(domain string) *tls.ClientHelloInfo {
+	return &tls.ClientHelloInfo{
+		ServerName:   domain,
+		CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+	}
+}

--- a/tlsmanager/warmer_test.go
+++ b/tlsmanager/warmer_test.go
@@ -1,0 +1,367 @@
+package tlsmanager
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"io"
+	"log/slog"
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/acme"
+	"golang.org/x/crypto/acme/autocert"
+
+	"github.com/migadu/alps/tlsmanager/storage"
+)
+
+var errTestS3Down = errors.New("test: s3 down")
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// memCache is a recording in-memory autocert.Cache. Driving the REAL
+// autocert.Manager against it proves which cache keys (i.e. which certificate
+// flavors) a synthetic ClientHello resolves to — the exact defect class a
+// hand-rolled hello can introduce (a bare hello resolves to "domain+rsa").
+type memCache struct {
+	mu   sync.Mutex
+	m    map[string][]byte
+	gets []string
+	puts []string
+}
+
+func newMemCache() *memCache {
+	return &memCache{m: make(map[string][]byte)}
+}
+
+func (c *memCache) Get(_ context.Context, name string) ([]byte, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.gets = append(c.gets, name)
+	if d, ok := c.m[name]; ok {
+		return d, nil
+	}
+	return nil, autocert.ErrCacheMiss
+}
+
+func (c *memCache) Put(_ context.Context, name string, data []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.puts = append(c.puts, name)
+	c.m[name] = data
+	return nil
+}
+
+func (c *memCache) Delete(_ context.Context, name string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.m, name)
+	return nil
+}
+
+func (c *memCache) getKeys() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.gets...)
+}
+
+// makeBundle builds a cert+key PEM bundle in autocert's storage format:
+// private-key block first, then the certificate chain.
+func makeBundle(t *testing.T, domain string, useRSA bool) []byte {
+	t.Helper()
+
+	var priv crypto.Signer
+	var keyBlock *pem.Block
+	if useRSA {
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			t.Fatal(err)
+		}
+		priv = key
+		keyBlock = &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}
+	} else {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		priv = key
+		b, err := x509.MarshalECPrivateKey(key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		keyBlock = &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: domain},
+		DNSNames:     []string{domain},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(90 * 24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, priv.Public(), priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	pem.Encode(&buf, keyBlock)
+	pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return buf.Bytes()
+}
+
+// newWarmerTestManager builds a Manager whose autocert instance reads from the
+// given cache and whose ACME client points at an unroutable directory, so any
+// attempted issuance fails instead of reaching a real CA.
+func newWarmerTestManager(t *testing.T, cache autocert.Cache) *Manager {
+	t.Helper()
+	return &Manager{
+		config: &Config{},
+		logger: discardLogger(),
+		autocertManager: &autocert.Manager{
+			Prompt:     autocert.AcceptTOS,
+			HostPolicy: autocert.HostWhitelist("example.com"),
+			Cache:      cache,
+			Client:     &acme.Client{DirectoryURL: "https://127.0.0.1:1/directory"},
+		},
+	}
+}
+
+// TestWarmer_ECDSAHelloResolvesDefaultFlavor is the load-bearing test: the
+// synthetic ECDSA hello must make the real autocert resolve the DEFAULT cache
+// key ("example.com" — the flavor real browsers request), not "example.com+rsa".
+func TestWarmer_ECDSAHelloResolvesDefaultFlavor(t *testing.T) {
+	cache := newMemCache()
+	cache.m["example.com"] = makeBundle(t, "example.com", false)
+
+	m := newWarmerTestManager(t, cache)
+	cert, err := m.autocertManager.GetCertificate(warmECDSAHello("example.com"))
+	if err != nil {
+		t.Fatalf("GetCertificate with ECDSA hello: %v (hello resolved to the wrong flavor and attempted issuance?)", err)
+	}
+	if _, ok := cert.Leaf.PublicKey.(*ecdsa.PublicKey); !ok {
+		t.Errorf("expected the ECDSA certificate, got %T", cert.Leaf.PublicKey)
+	}
+
+	for _, k := range cache.getKeys() {
+		if k == "example.com+rsa" {
+			t.Error("ECDSA hello must not touch the +rsa cache key")
+		}
+	}
+}
+
+// TestWarmer_RSAHelloResolvesRSAFlavor: the RSA hello must resolve "domain+rsa".
+func TestWarmer_RSAHelloResolvesRSAFlavor(t *testing.T) {
+	cache := newMemCache()
+	cache.m["example.com+rsa"] = makeBundle(t, "example.com", true)
+
+	m := newWarmerTestManager(t, cache)
+	cert, err := m.autocertManager.GetCertificate(warmRSAHello("example.com"))
+	if err != nil {
+		t.Fatalf("GetCertificate with RSA hello: %v", err)
+	}
+	if _, ok := cert.Leaf.PublicKey.(*rsa.PublicKey); !ok {
+		t.Errorf("expected the RSA certificate, got %T", cert.Leaf.PublicKey)
+	}
+}
+
+// TestWarmer_WarmsECDSAOnlyByDefault verifies a warm pass touches only the
+// default flavor unless RSA warming is opted into.
+func TestWarmer_WarmsECDSAOnlyByDefault(t *testing.T) {
+	cache := newMemCache()
+	cache.m["example.com"] = makeBundle(t, "example.com", false)
+	cache.m["example.com+rsa"] = makeBundle(t, "example.com", true)
+
+	m := newWarmerTestManager(t, cache)
+	w := newCertWarmer(m, []string{"example.com"}, false)
+	w.maybeWarm()
+
+	var sawDefault, sawRSA bool
+	for _, k := range cache.getKeys() {
+		switch k {
+		case "example.com":
+			sawDefault = true
+		case "example.com+rsa":
+			sawRSA = true
+		}
+	}
+	if !sawDefault {
+		t.Error("warm pass should have loaded the default (ECDSA) flavor")
+	}
+	if sawRSA {
+		t.Error("warm pass should not touch the RSA flavor unless warm_rsa_certs is set")
+	}
+}
+
+// TestWarmer_WarmsBothFlavorsWhenConfigured verifies warm_rsa_certs=true also
+// warms the legacy RSA flavor.
+func TestWarmer_WarmsBothFlavorsWhenConfigured(t *testing.T) {
+	cache := newMemCache()
+	cache.m["example.com"] = makeBundle(t, "example.com", false)
+	cache.m["example.com+rsa"] = makeBundle(t, "example.com", true)
+
+	m := newWarmerTestManager(t, cache)
+	w := newCertWarmer(m, []string{"example.com"}, true)
+	w.maybeWarm()
+
+	var sawDefault, sawRSA bool
+	for _, k := range cache.getKeys() {
+		switch k {
+		case "example.com":
+			sawDefault = true
+		case "example.com+rsa":
+			sawRSA = true
+		}
+	}
+	if !sawDefault || !sawRSA {
+		t.Errorf("warm pass with RSA warming should load both flavors (default=%v rsa=%v)", sawDefault, sawRSA)
+	}
+}
+
+// TestWarmer_SkipsWhenNotLeader: followers must never warm.
+func TestWarmer_SkipsWhenNotLeader(t *testing.T) {
+	cache := newMemCache()
+	cache.m["example.com"] = makeBundle(t, "example.com", false)
+
+	m := newWarmerTestManager(t, cache)
+	m.isLeader = func() bool { return false }
+	w := newCertWarmer(m, []string{"example.com"}, false)
+	w.maybeWarm()
+
+	if got := cache.getKeys(); len(got) != 0 {
+		t.Errorf("non-leader warm pass must not touch the cache, got %v", got)
+	}
+}
+
+// TestWarmer_SingleInstanceWarms: with no leadership wired (isLeader nil) the
+// sole node warms — proactive renewal replaces handshake-triggered renewal.
+func TestWarmer_SingleInstanceWarms(t *testing.T) {
+	cache := newMemCache()
+	cache.m["example.com"] = makeBundle(t, "example.com", false)
+
+	m := newWarmerTestManager(t, cache) // isLeader nil
+	w := newCertWarmer(m, []string{"example.com"}, false)
+	w.maybeWarm()
+
+	if got := cache.getKeys(); len(got) == 0 {
+		t.Error("single-instance warm pass should have run")
+	}
+}
+
+// TestWarmer_DeferredPassDoesNotBurnBudget: a pass skipped because S3 is
+// unhealthy must not consume the pass budget — the retry (via the pending
+// flag) must run as soon as S3 is worth probing again, not at the next 12h
+// tick.
+func TestWarmer_DeferredPassDoesNotBurnBudget(t *testing.T) {
+	cache := newMemCache()
+	cache.m["example.com"] = makeBundle(t, "example.com", false)
+
+	mock := storage.NewMockS3Client()
+	s3 := &storage.S3Cache{S3Client: mock, Bucket: "b", Prefix: "p/", Logger: discardLogger()}
+	fc := storage.NewFallbackCache(t.TempDir(), s3, discardLogger())
+
+	m := newWarmerTestManager(t, cache)
+	m.fallbackCache = fc
+	w := newCertWarmer(m, []string{"example.com"}, false)
+
+	// Open the breaker via a failing S3 op.
+	mock.GetErr = errTestS3Down
+	fc.Get(context.Background(), "missing.example.com")
+	mock.GetErr = nil
+
+	w.maybeWarm()
+	if got := len(cache.getKeys()); got != 0 {
+		t.Fatalf("pass must be deferred while S3 is unhealthy (%d cache reads)", got)
+	}
+	if !w.isPending() {
+		t.Fatal("deferred pass must be marked pending")
+	}
+
+	// S3 becomes worth probing again: the retry must run immediately — the
+	// deferral must not have consumed the 15-minute pass budget.
+	fc.SetRetryInterval(0)
+	w.maybeWarm()
+	if got := len(cache.getKeys()); got == 0 {
+		t.Error("retried pass should have run once S3 recovered")
+	}
+	if w.isPending() {
+		t.Error("pending flag should clear after a successful pass")
+	}
+}
+
+// TestWarmer_MinPassGap: back-to-back triggers must not run two passes.
+func TestWarmer_MinPassGap(t *testing.T) {
+	cache := newMemCache()
+	cache.m["example.com"] = makeBundle(t, "example.com", false)
+
+	m := newWarmerTestManager(t, cache)
+	w := newCertWarmer(m, []string{"example.com"}, false)
+
+	w.maybeWarm()
+	n := len(cache.getKeys())
+	w.maybeWarm() // Within warmerMinPassGap: must be a no-op.
+	if got := len(cache.getKeys()); got != n {
+		t.Errorf("second pass within warmerMinPassGap ran (%d -> %d cache reads)", n, got)
+	}
+}
+
+// TestNamespacedStorageConfig verifies a non-production ACME directory gets an
+// isolated store and production stays untouched.
+func TestNamespacedStorageConfig(t *testing.T) {
+	prod := LetsEncryptConfig{CacheDir: "cert-cache", S3: S3Config{Prefix: "alps/"}}
+	if got, ns := namespacedStorageConfig(prod); ns || got.CacheDir != "cert-cache" || got.S3.Prefix != "alps/" {
+		t.Errorf("production config must not be namespaced: %+v ns=%v", got, ns)
+	}
+
+	prodExplicit := prod
+	prodExplicit.DirectoryURL = autocert.DefaultACMEDirectory
+	if _, ns := namespacedStorageConfig(prodExplicit); ns {
+		t.Error("explicit production directory URL must not be namespaced")
+	}
+
+	staging := prod
+	staging.DirectoryURL = "https://acme-staging-v02.api.letsencrypt.org/directory"
+	got, ns := namespacedStorageConfig(staging)
+	if !ns {
+		t.Fatal("staging directory URL must be namespaced")
+	}
+	if got.CacheDir == prod.CacheDir {
+		t.Error("staging cache dir must differ from production")
+	}
+	if got.S3.Prefix == prod.S3.Prefix {
+		t.Error("staging S3 prefix must differ from production")
+	}
+
+	// Same URL -> same namespace (deterministic); different URL -> different.
+	got2, _ := namespacedStorageConfig(staging)
+	if got2.CacheDir != got.CacheDir || got2.S3.Prefix != got.S3.Prefix {
+		t.Error("namespacing must be deterministic")
+	}
+	other := prod
+	other.DirectoryURL = "https://acme.example.org/directory"
+	got3, _ := namespacedStorageConfig(other)
+	if got3.CacheDir == got.CacheDir {
+		t.Error("different directory URLs must map to different namespaces")
+	}
+
+	// Empty cache dir gets the default before suffixing.
+	empty := LetsEncryptConfig{DirectoryURL: "https://acme.example.org/directory"}
+	got4, _ := namespacedStorageConfig(empty)
+	if got4.CacheDir == "" || got4.CacheDir == "cert-cache" {
+		t.Errorf("empty cache dir should default then namespace, got %q", got4.CacheDir)
+	}
+}


### PR DESCRIPTION
Stage 1 of the clustered-TLS re-architecture. **Deploy this release fleet-wide before the stacked stage-2 PR** — stage 2 makes followers read-only for issuance and depends on the warmer and store semantics introduced here.

## Problem

In a cluster, ACME issuance today happens on whichever node a cold handshake lands on; the only gate (`ClusterAwareCache.Put`) sits *after* the Let's Encrypt dance, so it burns rate limit without preventing anything. Followers also never notice a leader-renewed cert until their own autocert wants to renew, and challenge tokens cached under the fixed `domain+token` key go stale and break future cross-node validations.

## Changes

**Cert warmer** (`tlsmanager/warmer.go`)
- Leader (or sole node) proactively obtains/renews certs for all configured domains every 12h, so the shared store is populated regardless of traffic routing.
- The synthetic ClientHello advertises ECDSA — a bare hello fails autocert's `supportsECDSA` and would issue only the legacy RSA flavor under `domain+rsa`, a cache key real browsers never read (verified by a test driving the real `autocert.Manager` against a recording fake cache). `warm_rsa_certs` optionally warms the RSA flavor too.
- Jittered 60–120s startup delay + per-domain leadership re-checks (fleet cold boot: every node briefly self-elects until memberlist join converges — warming immediately would stampede ACME from N nodes).
- Immediate pass on leadership acquisition; 15-min pass floor; passes deferred (not skipped) while the S3 breaker is open; after each pass a repair sync pushes local-only certs back to S3 (autocert is state-first and would otherwise never repopulate a wiped store).

**Store freshness** (`FallbackCache`)
- `Get()` on a local cert inside its renewal window (min(lifetime/3, 30d), matching autocert) re-checks S3 at most hourly per key and adopts a newer leader-published cert, fetch-then-swap. Deterministic, partition/restart-proof; zero S3 traffic outside the window. Follower staleness after a renewal is bounded by ~1h — weeks before expiry.
- Challenge tokens are now S3-only (never the local tier): the fixed `domain+token` key means a locally cached copy shadows the fresh token at the next renewal. Token reads are throttled (1s result reuse) so unauthenticated ALPN probes can't amplify into unbounded billable S3 GETs; publishing a token invalidates the throttle entry.
- New API: `RefreshFromS3` (S3-direct read, used by stage 2), `S3Healthy` (retry-window-aware), `SetRetryInterval`.

**ACME directory knob** (`tls.letsencrypt.directory_url`)
- Enables testing against Let's Encrypt staging. A non-production URL automatically namespaces the local cache dir and S3 prefix by a hash of the URL — staging certs can never be served from or written over the production store, by construction.

**Cluster config hardening** (`cmd/alps`)
- Cluster init failure is now **fatal** instead of a silent single-node fallback (an "ungated" node issues certs on its own and writes to the shared store; a fleet-wide config error would previously have made *every* node an independent issuer).
- Clustered Let's Encrypt requires `storage_provider = "s3"` at startup (file storage is node-local — followers would have no cert source).
- `storage_provider` now actually defaults to `"s3"` as documented.

## Verification

- Recording fake `autocert.Cache` driving the **real** `autocert.Manager` proves hello→flavor-key resolution mechanically.
- Tests: renewal-window adoption/throttling/S3-outage behavior, token tier bypass + throttle + publish-invalidation, breaker retry-window semantics, deferred-pass budget, staging namespacing determinism, config validation. `go vet` clean, full suite + `-race` green.
- This implementation was shaped by two adversarial multi-agent review passes (34 confirmed findings against the original design; 19 against the first implementation draft — all addressed or explicitly documented).

## Upgrade notes

- Single-instance deployments get proactive renewal (previously handshake-triggered only). Deployments whose cached certs are RSA-only will obtain one new ECDSA cert per domain on the first warm pass.
- Nodes with `cluster.enabled = true` that currently limp along in silent single-node fallback (e.g. bad gossip config) will now fail fast at startup with an actionable error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)