### PR TITLE
tls: gate ACME issuance at the handshake layer for cluster followers (stage 2/2)

### DIFF
--- a/tlsmanager/follower.go
+++ b/tlsmanager/follower.go
@@ -1,0 +1,351 @@
+package tlsmanager
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"time"
+
+	"golang.org/x/crypto/acme"
+)
+
+const (
+	// followerMemoTTL bounds how long a follower serves a parsed certificate
+	// from memory before re-reading the store. The store read is a local disk
+	// hit in the common case; the TTL is what lets a follower notice a cert
+	// the freshness revalidation (FallbackCache.maybeRevalidate) adopted.
+	followerMemoTTL = time.Minute
+
+	// followerEscapeThreshold is how long a follower tolerates a hard miss
+	// (no certificate anywhere in the store) before falling back to issuing
+	// locally. This is the availability escape hatch for a leader that is
+	// gossip-alive but functionally broken (cannot reach ACME or S3): it
+	// converts an indefinite cluster-wide outage into a bounded one, and is
+	// rate-limited by construction — it only fires when the leader has
+	// demonstrably published nothing for this long.
+	followerEscapeThreshold = 5 * time.Minute
+
+	// followerEscapeRetry bounds how often the escape hatch may ATTEMPT local
+	// issuance per flavor key, success or failure. Without it, a failing
+	// leaderIssue (e.g. ACME unreachable from this node too) would be retried
+	// on every incoming handshake — ~60 full ACME attempts/hour against Let's
+	// Encrypt's 5-failed-validations/hour budget. 15 minutes caps it at 4.
+	followerEscapeRetry = 15 * time.Minute
+)
+
+// followerCertEntry is a parsed, validated certificate memoized by a follower.
+type followerCertEntry struct {
+	cert     *tls.Certificate
+	loadedAt time.Time
+}
+
+// isALPNChallengeHello reports whether a handshake is an ACME tls-alpn-01
+// validation probe (mirrors autocert's wantsTokenCert). These must reach
+// autocert on every node: the challenge certificate is served from the shared
+// cache — a pure read, never an issuance — so validation succeeds regardless
+// of which node the CA's probe lands on.
+func isALPNChallengeHello(hello *tls.ClientHelloInfo) bool {
+	return len(hello.SupportedProtos) == 1 && hello.SupportedProtos[0] == acme.ALPNProto
+}
+
+// helloSupportsECDSA mirrors autocert's unexported supportsECDSA so followers
+// resolve the SAME flavor cache key ("domain" vs "domain+rsa") that autocert
+// would for the same ClientHello. Derived from
+// golang.org/x/crypto/acme/autocert (BSD-3-Clause).
+func helloSupportsECDSA(hello *tls.ClientHelloInfo) bool {
+	// The "signature_algorithms" extension, if present, limits the key exchange
+	// algorithms allowed by the cipher suites. See RFC 5246, section 7.4.1.4.1.
+	if hello.SignatureSchemes != nil {
+		ecdsaOK := false
+	schemeLoop:
+		for _, scheme := range hello.SignatureSchemes {
+			const tlsECDSAWithSHA1 tls.SignatureScheme = 0x0203
+			switch scheme {
+			case tlsECDSAWithSHA1, tls.ECDSAWithP256AndSHA256,
+				tls.ECDSAWithP384AndSHA384, tls.ECDSAWithP521AndSHA512:
+				ecdsaOK = true
+				break schemeLoop
+			}
+		}
+		if !ecdsaOK {
+			return false
+		}
+	}
+	if hello.SupportedCurves != nil {
+		ecdsaOK := false
+		for _, curve := range hello.SupportedCurves {
+			if curve == tls.CurveP256 {
+				ecdsaOK = true
+				break
+			}
+		}
+		if !ecdsaOK {
+			return false
+		}
+	}
+	for _, suite := range hello.CipherSuites {
+		switch suite {
+		case tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305:
+			return true
+		}
+	}
+	return false
+}
+
+// parseBundleKey parses the private-key block of an autocert cache bundle
+// (EC, PKCS#1, or PKCS#8 — the encodings autocert writes or accepts).
+func parseBundleKey(block *pem.Block) (crypto.Signer, error) {
+	if key, err := x509.ParseECPrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	if k, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
+		if signer, ok := k.(crypto.Signer); ok {
+			return signer, nil
+		}
+	}
+	return nil, errors.New("unsupported private key encoding in certificate bundle")
+}
+
+// parseCertBundle parses and validates a cert+key PEM bundle in autocert's
+// storage format (private-key block first, then the certificate chain) and
+// assembles a tls.Certificate. Validation mirrors autocert's validCert:
+// validity window, hostname, key/cert match, and flavor match — a follower
+// must reject from the shared store anything autocert itself would reject.
+func parseCertBundle(data []byte, domain string, wantRSA bool, now time.Time) (*tls.Certificate, error) {
+	keyBlock, rest := pem.Decode(data)
+	if keyBlock == nil || keyBlock.Type == "CERTIFICATE" {
+		return nil, errors.New("bundle does not start with a private key block")
+	}
+	privKey, err := parseBundleKey(keyBlock)
+	if err != nil {
+		return nil, err
+	}
+
+	var chain [][]byte
+	for len(rest) > 0 {
+		var b *pem.Block
+		b, rest = pem.Decode(rest)
+		if b == nil {
+			break
+		}
+		chain = append(chain, b.Bytes)
+	}
+	// Mirror autocert's cacheGet: leftover bytes that failed to decode mean
+	// a truncated or corrupted bundle — reject it entirely rather than serve
+	// a partial chain.
+	if len(rest) > 0 {
+		return nil, errors.New("bundle holds trailing non-PEM data (corrupt)")
+	}
+	if len(chain) == 0 {
+		return nil, errors.New("bundle holds no certificates")
+	}
+
+	// Mirror autocert's validCert: every element of the chain must be a
+	// parseable certificate, not just the leaf — a damaged intermediate
+	// would otherwise be handed to clients verbatim.
+	allDER := bytes.Join(chain, nil)
+	certs, err := x509.ParseCertificates(allDER)
+	if err != nil || len(certs) == 0 {
+		return nil, fmt.Errorf("parse certificate chain: %w", err)
+	}
+	leaf := certs[0]
+	if now.Before(leaf.NotBefore) {
+		return nil, errors.New("certificate is not valid yet")
+	}
+	if now.After(leaf.NotAfter) {
+		return nil, fmt.Errorf("certificate expired at %v", leaf.NotAfter)
+	}
+	if err := leaf.VerifyHostname(domain); err != nil {
+		return nil, err
+	}
+
+	switch pub := leaf.PublicKey.(type) {
+	case *rsa.PublicKey:
+		prv, ok := privKey.(*rsa.PrivateKey)
+		if !ok {
+			return nil, errors.New("private key type does not match certificate")
+		}
+		if pub.N.Cmp(prv.N) != 0 {
+			return nil, errors.New("private key does not match certificate")
+		}
+		if !wantRSA {
+			return nil, errors.New("certificate flavor mismatch: got RSA, want ECDSA")
+		}
+	case *ecdsa.PublicKey:
+		prv, ok := privKey.(*ecdsa.PrivateKey)
+		if !ok {
+			return nil, errors.New("private key type does not match certificate")
+		}
+		if pub.X.Cmp(prv.X) != 0 || pub.Y.Cmp(prv.Y) != 0 {
+			return nil, errors.New("private key does not match certificate")
+		}
+		if wantRSA {
+			return nil, errors.New("certificate flavor mismatch: got ECDSA, want RSA")
+		}
+	default:
+		return nil, errors.New("unsupported certificate public key type")
+	}
+
+	return &tls.Certificate{
+		Certificate: chain,
+		PrivateKey:  privKey,
+		Leaf:        leaf,
+	}, nil
+}
+
+// followerGetCertificate serves a TLS handshake on a cluster follower without
+// ever initiating ACME issuance: the leader populates the shared store (via
+// the cert warmer and its own handshakes) and followers read from it. On a
+// sustained hard miss the escape hatch falls back to local issuance so a
+// functionally dead leader cannot take cluster TLS down indefinitely.
+func (m *Manager) followerGetCertificate(hello *tls.ClientHelloInfo, domain string) (*tls.Certificate, error) {
+	wantRSA := !helloSupportsECDSA(hello)
+	flavorKey := domain
+	if wantRSA {
+		flavorKey += "+rsa"
+	}
+	now := time.Now()
+
+	m.followerMu.Lock()
+	if m.followerCerts == nil {
+		m.followerCerts = make(map[string]*followerCertEntry)
+		m.followerFirstMiss = make(map[string]time.Time)
+		m.followerLastEscape = make(map[string]time.Time)
+	}
+	if e, ok := m.followerCerts[flavorKey]; ok &&
+		now.Sub(e.loadedAt) < followerMemoTTL && now.Before(e.cert.Leaf.NotAfter) {
+		m.followerMu.Unlock()
+		return e.cert, nil
+	}
+	m.followerMu.Unlock()
+
+	ctx := hello.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	cert := m.loadFollowerCert(ctx, flavorKey, domain, wantRSA, now)
+	if cert != nil {
+		m.followerMu.Lock()
+		m.followerCerts[flavorKey] = &followerCertEntry{cert: cert, loadedAt: now}
+		delete(m.followerFirstMiss, flavorKey)
+		m.followerMu.Unlock()
+		return cert, nil
+	}
+
+	// Hard miss: nothing servable in the store. Before failing the
+	// handshake, fall back to a memoized cert that is past its TTL but still
+	// time-valid — e.g. one obtained by an earlier escape-hatch issuance
+	// that, being absorbed by the leader gate, never reached the store.
+	// Without this, a broken-leader outage becomes a sawtooth: 60s of
+	// service per memo TTL followed by minutes of failed handshakes. The
+	// lease is renewed so the store is re-probed once per TTL, letting the
+	// follower converge back to the leader's cert as soon as it appears.
+	m.followerMu.Lock()
+	if e, ok := m.followerCerts[flavorKey]; ok && now.Before(e.cert.Leaf.NotAfter) {
+		e.loadedAt = now
+		m.followerMu.Unlock()
+		m.logger.Warn("TLS: shared store has no servable certificate - serving previously obtained certificate",
+			"domain", domain, "key", flavorKey, "cert_expires", e.cert.Leaf.NotAfter)
+		return e.cert, nil
+	}
+
+	first, seen := m.followerFirstMiss[flavorKey]
+	if !seen {
+		first = now
+		m.followerFirstMiss[flavorKey] = now
+	}
+	elapsed := now.Sub(first)
+	lastEscape := m.followerLastEscape[flavorKey]
+	m.followerMu.Unlock()
+
+	if elapsed >= followerEscapeThreshold && m.leaderIssue != nil {
+		// The escape hatch never fires for a flavor the leader is not
+		// expected to publish: with warm_rsa_certs disabled the "+rsa" key
+		// is legitimately absent, and any client can fabricate an RSA-only
+		// ClientHello — escaping here would let unauthenticated handshakes
+		// drive ACME issuance on every follower.
+		if wantRSA && !m.warmRSA {
+			m.logger.Warn("TLS: no RSA certificate published and RSA warming is disabled - rejecting legacy-client handshake (enable warm_rsa_certs to serve RSA-only clients)",
+				"domain", domain)
+			return nil, fmt.Errorf("%w for %s: RSA certificate flavor not provisioned", ErrCertificateUnavailable, domain)
+		}
+
+		// Attempt-based cooldown: at most one local issuance attempt per
+		// flavor per followerEscapeRetry, success or failure.
+		if now.Sub(lastEscape) < followerEscapeRetry {
+			m.logger.Warn("TLS: follower escape hatch in cooldown after a recent issuance attempt",
+				"domain", domain, "key", flavorKey, "since_last_attempt", now.Sub(lastEscape))
+			return nil, fmt.Errorf("%w for %s: certificate not yet published by cluster leader", ErrCertificateUnavailable, domain)
+		}
+		m.followerMu.Lock()
+		m.followerLastEscape[flavorKey] = now
+		m.followerMu.Unlock()
+
+		m.logger.Error("TLS: follower escape hatch - cluster leader has published no certificate; issuing locally",
+			"domain", domain, "key", flavorKey, "waited", elapsed)
+		cert, err := m.leaderIssue(hello)
+		if err != nil {
+			m.logger.Error("TLS: follower escape hatch issuance failed",
+				"domain", domain, "key", flavorKey, "error", err, "retry_in", followerEscapeRetry)
+			return nil, err
+		}
+		m.followerMu.Lock()
+		m.followerCerts[flavorKey] = &followerCertEntry{cert: cert, loadedAt: time.Now()}
+		delete(m.followerFirstMiss, flavorKey)
+		m.followerMu.Unlock()
+		return cert, nil
+	}
+
+	m.logger.Warn("TLS: follower has no certificate for domain - waiting for cluster leader to publish",
+		"domain", domain, "key", flavorKey, "waiting", elapsed, "escape_after", followerEscapeThreshold)
+	return nil, fmt.Errorf("%w for %s: certificate not yet published by cluster leader", ErrCertificateUnavailable, domain)
+}
+
+// loadFollowerCert reads a certificate bundle from the shared store and
+// validates it. The plain Get is local-first (with S3 fallback and in-window
+// freshness revalidation); if what it returns is unservable — e.g. an expired
+// local copy pinned by revalidation throttling while the leader has already
+// published a renewal — a direct S3 refresh is attempted before giving up.
+func (m *Manager) loadFollowerCert(ctx context.Context, flavorKey, domain string, wantRSA bool, now time.Time) *tls.Certificate {
+	if m.fallbackCache == nil {
+		// Defensive: the follower path requires shared S3 storage (enforced
+		// at startup for clustered deployments).
+		m.logger.Error("TLS: follower path without shared certificate storage - cannot serve", "domain", domain)
+		return nil
+	}
+
+	if data, err := m.fallbackCache.Get(ctx, flavorKey); err == nil {
+		cert, perr := parseCertBundle(data, domain, wantRSA, now)
+		if perr == nil {
+			return cert
+		}
+		m.logger.Warn("TLS: stored certificate not servable - refreshing from S3",
+			"domain", domain, "key", flavorKey, "error", perr)
+		if data, err := m.fallbackCache.RefreshFromS3(ctx, flavorKey); err == nil {
+			cert, perr := parseCertBundle(data, domain, wantRSA, now)
+			if perr == nil {
+				return cert
+			}
+			m.logger.Warn("TLS: S3 certificate not servable either",
+				"domain", domain, "key", flavorKey, "error", perr)
+		}
+	}
+	return nil
+}

--- a/tlsmanager/follower_test.go
+++ b/tlsmanager/follower_test.go
@@ -1,0 +1,477 @@
+package tlsmanager
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/migadu/alps/tlsmanager/storage"
+)
+
+// makeBundleAt is makeBundle with an explicit validity window.
+func makeBundleAt(t *testing.T, domain string, useRSA bool, notBefore, notAfter time.Time) []byte {
+	t.Helper()
+
+	var priv crypto.Signer
+	var keyBlock *pem.Block
+	if useRSA {
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			t.Fatal(err)
+		}
+		priv = key
+		keyBlock = &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}
+	} else {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		priv = key
+		b, err := x509.MarshalECPrivateKey(key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		keyBlock = &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: domain},
+		DNSNames:     []string{domain},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, priv.Public(), priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	pem.Encode(&buf, keyBlock)
+	pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return buf.Bytes()
+}
+
+func TestIsALPNChallengeHello(t *testing.T) {
+	cases := []struct {
+		protos []string
+		want   bool
+	}{
+		{[]string{"acme-tls/1"}, true},
+		{nil, false},
+		{[]string{}, false},
+		{[]string{"h2"}, false},
+		{[]string{"acme-tls/1", "h2"}, false}, // real CA probes offer ONLY acme-tls/1
+	}
+	for _, c := range cases {
+		hello := &tls.ClientHelloInfo{ServerName: "example.com", SupportedProtos: c.protos}
+		if got := isALPNChallengeHello(hello); got != c.want {
+			t.Errorf("isALPNChallengeHello(%v) = %v, want %v", c.protos, got, c.want)
+		}
+	}
+}
+
+func TestHelloSupportsECDSA(t *testing.T) {
+	if !helloSupportsECDSA(warmECDSAHello("example.com")) {
+		t.Error("the warmer's ECDSA hello must resolve as ECDSA-capable")
+	}
+	if helloSupportsECDSA(warmRSAHello("example.com")) {
+		t.Error("the warmer's RSA hello must not resolve as ECDSA-capable")
+	}
+	// The exact trap this mirror exists for: a bare hello is NOT ECDSA-capable.
+	if helloSupportsECDSA(&tls.ClientHelloInfo{ServerName: "example.com"}) {
+		t.Error("a bare ClientHelloInfo must resolve to the RSA flavor (autocert semantics)")
+	}
+	// ECDSA signature scheme but no ECDSA cipher suite: still not capable.
+	if helloSupportsECDSA(&tls.ClientHelloInfo{
+		ServerName:       "example.com",
+		SignatureSchemes: []tls.SignatureScheme{tls.ECDSAWithP256AndSHA256},
+	}) {
+		t.Error("signature scheme alone (no ECDSA cipher suite) must not resolve as ECDSA-capable")
+	}
+}
+
+func TestParseCertBundle(t *testing.T) {
+	now := time.Now()
+	valid := func() (time.Time, time.Time) { return now.Add(-time.Hour), now.Add(60 * 24 * time.Hour) }
+
+	nb, na := valid()
+	ecdsaBundle := makeBundleAt(t, "example.com", false, nb, na)
+	rsaBundle := makeBundleAt(t, "example.com", true, nb, na)
+
+	cert, err := parseCertBundle(ecdsaBundle, "example.com", false, now)
+	if err != nil {
+		t.Fatalf("valid ECDSA bundle: %v", err)
+	}
+	if cert.Leaf == nil {
+		t.Error("Leaf must be populated (avoids per-handshake re-parsing)")
+	}
+
+	if _, err := parseCertBundle(rsaBundle, "example.com", true, now); err != nil {
+		t.Errorf("valid RSA bundle: %v", err)
+	}
+
+	// Flavor mismatches must be rejected (mirrors autocert's validCert).
+	if _, err := parseCertBundle(ecdsaBundle, "example.com", true, now); err == nil {
+		t.Error("ECDSA bundle under the +rsa key must be rejected")
+	}
+	if _, err := parseCertBundle(rsaBundle, "example.com", false, now); err == nil {
+		t.Error("RSA bundle under the default key must be rejected")
+	}
+
+	// Expired and not-yet-valid.
+	expired := makeBundleAt(t, "example.com", false, now.Add(-48*time.Hour), now.Add(-time.Hour))
+	if _, err := parseCertBundle(expired, "example.com", false, now); err == nil {
+		t.Error("expired bundle must be rejected")
+	}
+	future := makeBundleAt(t, "example.com", false, now.Add(time.Hour), now.Add(60*24*time.Hour))
+	if _, err := parseCertBundle(future, "example.com", false, now); err == nil {
+		t.Error("not-yet-valid bundle must be rejected")
+	}
+
+	// Hostname mismatch.
+	if _, err := parseCertBundle(ecdsaBundle, "other.example.com", false, now); err == nil {
+		t.Error("hostname mismatch must be rejected")
+	}
+
+	// Garbage and key-less bundles.
+	if _, err := parseCertBundle([]byte("garbage"), "example.com", false, now); err == nil {
+		t.Error("garbage must be rejected")
+	}
+	certOnly := ecdsaBundle[bytes.Index(ecdsaBundle, []byte("-----BEGIN CERT")):]
+	if _, err := parseCertBundle(certOnly, "example.com", false, now); err == nil {
+		t.Error("bundle without a leading private key must be rejected")
+	}
+
+	// Autocert parity: trailing non-PEM data means a corrupt bundle.
+	truncated := append(append([]byte{}, ecdsaBundle...), []byte("-----BEGIN CERTIFICATE-----\ntruncated")...)
+	if _, err := parseCertBundle(truncated, "example.com", false, now); err == nil {
+		t.Error("bundle with trailing garbage must be rejected (autocert treats it as corrupt)")
+	}
+
+	// Autocert parity: every chain element must parse, not just the leaf.
+	damagedIntermediate := append(append([]byte{}, ecdsaBundle...),
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("not-der")})...)
+	if _, err := parseCertBundle(damagedIntermediate, "example.com", false, now); err == nil {
+		t.Error("bundle with an unparseable chain element must be rejected")
+	}
+}
+
+// newFollowerTestManager builds a follower Manager backed by a FallbackCache
+// over the mock S3, returning the manager, the S3 cache (for seeding S3
+// directly), and the local cache dir (for seeding the local tier directly).
+func newFollowerTestManager(t *testing.T) (*Manager, *storage.S3Cache, string) {
+	t.Helper()
+	s3 := &storage.S3Cache{
+		S3Client: storage.NewMockS3Client(),
+		Bucket:   "b",
+		Prefix:   "certs/",
+		Logger:   discardLogger(),
+	}
+	dir := t.TempDir()
+	fc := storage.NewFallbackCache(dir, s3, discardLogger())
+	m := &Manager{
+		config:        &Config{},
+		logger:        discardLogger(),
+		fallbackCache: fc,
+		isLeader:      func() bool { return false },
+	}
+	return m, s3, dir
+}
+
+func TestFollower_ServesPublishedCert(t *testing.T) {
+	m, s3, _ := newFollowerTestManager(t)
+	ctx := context.Background()
+
+	bundle := makeBundleAt(t, "example.com", false, time.Now().Add(-time.Hour), time.Now().Add(60*24*time.Hour))
+	if err := s3.Put(ctx, "example.com", bundle); err != nil {
+		t.Fatal(err)
+	}
+
+	cert, err := m.followerGetCertificate(warmECDSAHello("example.com"), "example.com")
+	if err != nil {
+		t.Fatalf("follower should serve the leader-published cert from S3: %v", err)
+	}
+	if _, ok := cert.Leaf.PublicKey.(*ecdsa.PublicKey); !ok {
+		t.Errorf("expected ECDSA cert, got %T", cert.Leaf.PublicKey)
+	}
+}
+
+func TestFollower_FlavorKeysAreSeparate(t *testing.T) {
+	m, s3, _ := newFollowerTestManager(t)
+	ctx := context.Background()
+
+	// Only the ECDSA flavor is published.
+	bundle := makeBundleAt(t, "example.com", false, time.Now().Add(-time.Hour), time.Now().Add(60*24*time.Hour))
+	if err := s3.Put(ctx, "example.com", bundle); err != nil {
+		t.Fatal(err)
+	}
+
+	// An RSA-only client resolves "example.com+rsa", which nobody published.
+	if _, err := m.followerGetCertificate(warmRSAHello("example.com"), "example.com"); err == nil {
+		t.Error("RSA-flavor request must miss when only the ECDSA flavor is published")
+	}
+}
+
+func TestFollower_MemoServesAfterStoreLoss(t *testing.T) {
+	m, s3, dir := newFollowerTestManager(t)
+	ctx := context.Background()
+
+	bundle := makeBundleAt(t, "example.com", false, time.Now().Add(-time.Hour), time.Now().Add(60*24*time.Hour))
+	if err := s3.Put(ctx, "example.com", bundle); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.followerGetCertificate(warmECDSAHello("example.com"), "example.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wipe both tiers; the memo must still serve within its TTL.
+	if err := s3.Delete(ctx, "example.com"); err != nil {
+		t.Fatal(err)
+	}
+	os.Remove(filepath.Join(dir, "example.com"))
+
+	if _, err := m.followerGetCertificate(warmECDSAHello("example.com"), "example.com"); err != nil {
+		t.Errorf("memoized cert should serve within followerMemoTTL: %v", err)
+	}
+}
+
+func TestFollower_RefreshesWhenLocalCopyUnservable(t *testing.T) {
+	m, s3, dir := newFollowerTestManager(t)
+	ctx := context.Background()
+
+	// Local tier holds garbage (e.g. a corrupt file); S3 has the real cert.
+	if err := os.WriteFile(filepath.Join(dir, "example.com"), []byte("corrupt"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	bundle := makeBundleAt(t, "example.com", false, time.Now().Add(-time.Hour), time.Now().Add(60*24*time.Hour))
+	if err := s3.Put(ctx, "example.com", bundle); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := m.followerGetCertificate(warmECDSAHello("example.com"), "example.com"); err != nil {
+		t.Errorf("unservable local copy should trigger an S3 refresh: %v", err)
+	}
+}
+
+func TestFollower_AdoptsRenewedCertOverExpiredLocal(t *testing.T) {
+	m, s3, dir := newFollowerTestManager(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	expired := makeBundleAt(t, "example.com", false, now.Add(-90*24*time.Hour), now.Add(-time.Hour))
+	fresh := makeBundleAt(t, "example.com", false, now.Add(-time.Hour), now.Add(89*24*time.Hour))
+
+	if err := os.WriteFile(filepath.Join(dir, "example.com"), expired, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := s3.Put(ctx, "example.com", fresh); err != nil {
+		t.Fatal(err)
+	}
+
+	cert, err := m.followerGetCertificate(warmECDSAHello("example.com"), "example.com")
+	if err != nil {
+		t.Fatalf("follower should adopt the renewed cert from S3 over the expired local copy: %v", err)
+	}
+	if !cert.Leaf.NotAfter.After(now) {
+		t.Error("served cert is expired")
+	}
+}
+
+func TestFollower_EscapeHatchAfterThreshold(t *testing.T) {
+	m, _, _ := newFollowerTestManager(t)
+
+	issued := 0
+	bundle := makeBundleAt(t, "example.com", false, time.Now().Add(-time.Hour), time.Now().Add(60*24*time.Hour))
+	stub, err := parseCertBundle(bundle, "example.com", false, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.leaderIssue = func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		issued++
+		return stub, nil
+	}
+
+	// Before the threshold: fail, do NOT issue.
+	if _, err := m.followerGetCertificate(warmECDSAHello("example.com"), "example.com"); err == nil {
+		t.Fatal("hard miss before the escape threshold must fail, not issue")
+	}
+	if issued != 0 {
+		t.Fatalf("leaderIssue called %d times before the threshold", issued)
+	}
+
+	// Simulate the miss persisting past the threshold.
+	m.followerMu.Lock()
+	m.followerFirstMiss["example.com"] = time.Now().Add(-followerEscapeThreshold - time.Minute)
+	m.followerMu.Unlock()
+
+	cert, err := m.followerGetCertificate(warmECDSAHello("example.com"), "example.com")
+	if err != nil {
+		t.Fatalf("escape hatch should issue after the threshold: %v", err)
+	}
+	if issued != 1 {
+		t.Errorf("leaderIssue called %d times, want 1", issued)
+	}
+	if cert != stub {
+		t.Error("escape hatch should return the issued cert")
+	}
+
+	// The issued cert is memoized: the next handshake must not re-issue.
+	if _, err := m.followerGetCertificate(warmECDSAHello("example.com"), "example.com"); err != nil {
+		t.Fatal(err)
+	}
+	if issued != 1 {
+		t.Errorf("issued cert should be memoized; leaderIssue called %d times", issued)
+	}
+}
+
+// TestFollower_NoSawtoothAfterEscape is the anti-regression test for the
+// review's top finding: after an escape-hatch issuance whose cert never
+// reaches the store (absorbed by the leader gate), handshakes past the memo
+// TTL must KEEP serving the still-valid cert — not fail for another 5-minute
+// threshold window (a 60s-up/5min-down availability sawtooth).
+func TestFollower_NoSawtoothAfterEscape(t *testing.T) {
+	m, _, _ := newFollowerTestManager(t)
+
+	issued := 0
+	bundle := makeBundleAt(t, "example.com", false, time.Now().Add(-time.Hour), time.Now().Add(60*24*time.Hour))
+	stub, err := parseCertBundle(bundle, "example.com", false, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.leaderIssue = func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		issued++
+		return stub, nil
+	}
+
+	// Trigger the escape hatch (store empty, threshold elapsed).
+	if _, err := m.followerGetCertificate(warmECDSAHello("example.com"), "example.com"); err == nil {
+		t.Fatal("expected pre-threshold miss")
+	}
+	m.followerMu.Lock()
+	m.followerFirstMiss["example.com"] = time.Now().Add(-followerEscapeThreshold - time.Minute)
+	m.followerMu.Unlock()
+	if _, err := m.followerGetCertificate(warmECDSAHello("example.com"), "example.com"); err != nil {
+		t.Fatalf("escape hatch: %v", err)
+	}
+	if issued != 1 {
+		t.Fatalf("expected 1 issuance, got %d", issued)
+	}
+
+	// Expire the memo TTL; the store is still empty (absorbed Put).
+	m.followerMu.Lock()
+	m.followerCerts["example.com"].loadedAt = time.Now().Add(-2 * followerMemoTTL)
+	m.followerMu.Unlock()
+
+	cert, err := m.followerGetCertificate(warmECDSAHello("example.com"), "example.com")
+	if err != nil {
+		t.Fatalf("post-TTL handshake must serve the still-valid escape cert, got error: %v", err)
+	}
+	if cert != stub {
+		t.Error("expected the previously issued cert")
+	}
+	if issued != 1 {
+		t.Errorf("stale-memo serve must not re-issue (issued=%d)", issued)
+	}
+
+	// The lease renews: another immediate handshake serves from memo.
+	if _, err := m.followerGetCertificate(warmECDSAHello("example.com"), "example.com"); err != nil {
+		t.Fatalf("re-leased memo should serve: %v", err)
+	}
+}
+
+// TestFollower_EscapeRetryCooldown: a FAILING escape issuance must not be
+// retried on every handshake (each retry is a full ACME attempt).
+func TestFollower_EscapeRetryCooldown(t *testing.T) {
+	m, _, _ := newFollowerTestManager(t)
+
+	attempts := 0
+	issueErr := fmt.Errorf("acme unreachable")
+	m.leaderIssue = func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		attempts++
+		return nil, issueErr
+	}
+
+	// Arm the threshold, then fail the first escape attempt.
+	if _, err := m.followerGetCertificate(warmECDSAHello("example.com"), "example.com"); err == nil {
+		t.Fatal("expected pre-threshold miss")
+	}
+	m.followerMu.Lock()
+	m.followerFirstMiss["example.com"] = time.Now().Add(-followerEscapeThreshold - time.Minute)
+	m.followerMu.Unlock()
+	if _, err := m.followerGetCertificate(warmECDSAHello("example.com"), "example.com"); err == nil {
+		t.Fatal("escape with failing issuer should error")
+	}
+	if attempts != 1 {
+		t.Fatalf("expected 1 attempt, got %d", attempts)
+	}
+
+	// Immediate retries stay in cooldown: no further ACME attempts.
+	for i := 0; i < 5; i++ {
+		if _, err := m.followerGetCertificate(warmECDSAHello("example.com"), "example.com"); err == nil {
+			t.Fatal("cooldown handshake should still error")
+		}
+	}
+	if attempts != 1 {
+		t.Errorf("cooldown must prevent per-handshake ACME retries (attempts=%d)", attempts)
+	}
+
+	// Cooldown expiry re-enables exactly one more attempt.
+	m.followerMu.Lock()
+	m.followerLastEscape["example.com"] = time.Now().Add(-followerEscapeRetry - time.Minute)
+	m.followerMu.Unlock()
+	m.followerGetCertificate(warmECDSAHello("example.com"), "example.com")
+	if attempts != 2 {
+		t.Errorf("expected a second attempt after cooldown, got %d", attempts)
+	}
+}
+
+// TestFollower_NoEscapeForUnwarmedRSAFlavor: with RSA warming disabled the
+// "+rsa" key is legitimately absent, and any client can fabricate an RSA-only
+// hello — the escape hatch must not let that drive ACME issuance.
+func TestFollower_NoEscapeForUnwarmedRSAFlavor(t *testing.T) {
+	m, _, _ := newFollowerTestManager(t)
+
+	attempts := 0
+	m.leaderIssue = func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		attempts++
+		return nil, fmt.Errorf("should not be called")
+	}
+
+	m.warmRSA = false
+	if _, err := m.followerGetCertificate(warmRSAHello("example.com"), "example.com"); err == nil {
+		t.Fatal("expected miss for unpublished RSA flavor")
+	}
+	m.followerMu.Lock()
+	m.followerFirstMiss["example.com+rsa"] = time.Now().Add(-followerEscapeThreshold - time.Minute)
+	m.followerMu.Unlock()
+	if _, err := m.followerGetCertificate(warmRSAHello("example.com"), "example.com"); err == nil {
+		t.Fatal("RSA escape with warming disabled should error")
+	}
+	if attempts != 0 {
+		t.Errorf("escape hatch must not fire for the unwarmed RSA flavor (attempts=%d)", attempts)
+	}
+
+	// With RSA warming enabled the flavor IS expected: escape may fire.
+	m.warmRSA = true
+	m.followerGetCertificate(warmRSAHello("example.com"), "example.com")
+	if attempts != 1 {
+		t.Errorf("escape hatch should fire for the RSA flavor when warming is enabled (attempts=%d)", attempts)
+	}
+}

--- a/tlsmanager/manager.go
+++ b/tlsmanager/manager.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -79,6 +80,19 @@ type Manager struct {
 	fallbackCache   *storage.FallbackCache  // Retained for follower refresh / warmer S3-health checks (nil unless S3 storage)
 	isLeader        func() bool             // Cluster leadership; nil in single-instance mode
 	warmer          *certWarmer             // Proactive issuance/renewal loop (nil unless Let's Encrypt)
+
+	// Follower-path state (cluster mode): memoized parsed certificates and
+	// hard-miss tracking for the escape hatch. leaderIssue is the full
+	// autocert path a follower falls back to when the leader has published
+	// nothing for followerEscapeThreshold; followerLastEscape rate-limits
+	// those attempts. warmRSA mirrors LetsEncryptConfig.WarmRSACerts: the
+	// escape hatch only fires for flavors the leader is expected to publish.
+	followerMu         sync.Mutex
+	followerCerts      map[string]*followerCertEntry
+	followerFirstMiss  map[string]time.Time
+	followerLastEscape map[string]time.Time
+	leaderIssue        func(*tls.ClientHelloInfo) (*tls.Certificate, error)
+	warmRSA            bool
 }
 
 // NewManager creates a new TLS manager.
@@ -248,8 +262,10 @@ func (m *Manager) initAutocert(isLeaderF ...func() bool) error {
 	baseTLSConfig := autocertMgr.TLSConfig()
 	baseTLSConfig.MinVersion = tls.VersionTLS12
 
-	// Wrap GetCertificate with enhanced logging and SNI handling
+	// Wrap GetCertificate with enhanced logging, SNI handling, and cluster
+	// issuance gating.
 	originalGetCert := baseTLSConfig.GetCertificate
+	m.leaderIssue = originalGetCert
 	baseTLSConfig.GetCertificate = func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 		serverName := hello.ServerName
 
@@ -280,6 +296,23 @@ func (m *Manager) initAutocert(isLeaderF ...func() bool) error {
 		modifiedHello := *hello
 		modifiedHello.ServerName = serverName
 
+		// ACME tls-alpn-01 validation probes must reach autocert on EVERY
+		// node — leader or follower. autocert tries this challenge type
+		// first, the CA's probe can land on any node behind the load
+		// balancer, and serving it is a pure read of the challenge cert
+		// from the shared cache (never an issuance).
+		if isALPNChallengeHello(hello) {
+			m.logger.Debug("TLS: serving tls-alpn-01 challenge handshake", "domain", serverName)
+			return originalGetCert(&modifiedHello)
+		}
+
+		// Cluster followers never initiate ACME issuance. They serve from
+		// the shared store the leader populates; on a sustained hard miss
+		// the escape hatch in followerGetCertificate issues locally.
+		if m.isLeader != nil && !m.isLeader() {
+			return m.followerGetCertificate(&modifiedHello, serverName)
+		}
+
 		cert, err := originalGetCert(&modifiedHello)
 		if err != nil {
 			m.logger.Error("TLS: failed to get certificate", "server_name", serverName, "error", err)
@@ -294,6 +327,7 @@ func (m *Manager) initAutocert(isLeaderF ...func() bool) error {
 	// shared store is always populated regardless of which node receives
 	// traffic. In a cluster only the leader runs warm passes; in
 	// single-instance mode the sole node does.
+	m.warmRSA = cfg.WarmRSACerts
 	m.warmer = newCertWarmer(m, cfg.Domains, cfg.WarmRSACerts)
 	m.warmer.Start()
 

--- a/tlsmanager/storage/cluster_cache.go
+++ b/tlsmanager/storage/cluster_cache.go
@@ -8,12 +8,36 @@ import (
 	"golang.org/x/crypto/acme/autocert"
 )
 
-// ClusterAwareCache wraps an autocert.Cache and only allows the cluster leader
-// to write new certificates. All nodes can read certificates from the cache.
+// acmeAccountKeys are the cache keys autocert uses for the shared ACME account
+// key (current and legacy names). They always pass through the leader gate:
+// absorbing an account-key write is a hard issuance error in autocert, and a
+// follower running the escape hatch must be able to (re)use the shared account
+// instead of registering a fresh ACME account per issuance.
+var acmeAccountKeys = map[string]bool{
+	"acme_account+key": true,
+	"acme_account.key": true,
+}
+
+// ClusterAwareCache wraps an autocert.Cache and only persists certificate
+// writes from the cluster leader. All nodes can read from the cache.
 //
-// This prevents race conditions with Let's Encrypt when multiple nodes
-// simultaneously request certificates for the same domain, which could trigger
-// Let's Encrypt rate limits.
+// This is defense-in-depth behind the issuance-level gating in the TLS
+// manager: even if a non-leader ends up running the autocert issuance path
+// (escape hatch, renewal timers armed before a demotion, a future bug), its
+// certificates never reach the shared store.
+//
+// Non-leader certificate writes are ABSORBED (logged, dropped, nil error)
+// rather than rejected: autocert's renewal path treats a failed Cache.Put as
+// a failed renewal and re-runs the FULL ACME issuance on a 30-60 minute
+// backoff, so an error-returning gate turns a demoted ex-leader with armed
+// renewal timers into a duplicate-issuance loop that exhausts Let's Encrypt's
+// duplicate-certificate limit. Absorbing lets the renewal complete (in-memory
+// only, one issuance at most); the node adopts the real leader's certificate
+// from the shared store at its next renewal check.
+//
+// Challenge tokens and the ACME account key always pass through: tokens must
+// be readable by whichever node the CA's validation probe lands on, and both
+// are prerequisites for any node that legitimately issues.
 type ClusterAwareCache struct {
 	underlying autocert.Cache
 	isLeaderF  func() bool
@@ -53,19 +77,28 @@ func (c *ClusterAwareCache) Get(ctx context.Context, name string) ([]byte, error
 	return data, nil
 }
 
-// Put stores a certificate in the cache (only leader can write).
-// Non-leader nodes will return an error to prevent duplicate Let's Encrypt requests.
+// Put stores a certificate in the cache. Only the cluster leader's
+// certificate writes are persisted; challenge tokens and the ACME account key
+// pass through from any node (see the type comment for the full rationale).
 func (c *ClusterAwareCache) Put(ctx context.Context, name string, data []byte) error {
 	isLeader := c.isLeaderF()
 
+	// Tokens must be published by whichever node runs a validation (leader
+	// normally; a follower under the escape hatch), and account-key writes
+	// error out issuance entirely if blocked.
+	if isChallengeToken(name) || acmeAccountKeys[name] {
+		c.logger.Info("cluster cache: storing ACME operational key", "name", name, "is_leader", isLeader)
+		return c.underlying.Put(ctx, name, data)
+	}
+
 	c.logger.Info("cluster cache: Put certificate request", "name", name, "is_leader", isLeader)
 
-	// Check if this node is the cluster leader
 	if !isLeader {
-		// Non-leader nodes should not write certificates
-		// This prevents race conditions with Let's Encrypt
-		c.logger.Warn("cluster cache: certificate request BLOCKED - not cluster leader (leader will handle it)", "name", name)
-		return fmt.Errorf("only cluster leader can request new certificates")
+		// Absorb, do NOT error: an error here makes autocert's renewal loop
+		// re-run full ACME issuance every 30-60 minutes (see type comment).
+		// The certificate stays in this node's autocert memory only.
+		c.logger.Warn("cluster cache: absorbing certificate write from non-leader (not persisted to shared store)", "name", name)
+		return nil
 	}
 
 	c.logger.Info("cluster cache: cluster leader storing certificate", "name", name)
@@ -79,16 +112,21 @@ func (c *ClusterAwareCache) Put(ctx context.Context, name string, data []byte) e
 	return nil
 }
 
-// Delete removes a certificate from the cache (only leader can delete).
+// Delete removes a certificate from the cache. Non-leader certificate deletes
+// are absorbed; challenge-token deletes pass through from any node (autocert
+// cleans up its own token right after validation, wherever it ran).
 func (c *ClusterAwareCache) Delete(ctx context.Context, name string) error {
 	isLeader := c.isLeaderF()
 
 	c.logger.Debug("cluster cache: Delete certificate request", "name", name, "is_leader", isLeader)
 
-	// Check if this node is the cluster leader
+	if isChallengeToken(name) {
+		return c.underlying.Delete(ctx, name)
+	}
+
 	if !isLeader {
-		c.logger.Debug("cluster cache: skipping certificate delete (not cluster leader)", "name", name)
-		return fmt.Errorf("only cluster leader can delete certificates")
+		c.logger.Debug("cluster cache: absorbing certificate delete from non-leader", "name", name)
+		return nil
 	}
 
 	c.logger.Info("cluster cache: cluster leader deleting certificate", "name", name)

--- a/tlsmanager/storage/cluster_cache_test.go
+++ b/tlsmanager/storage/cluster_cache_test.go
@@ -1,0 +1,137 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"testing"
+
+	"golang.org/x/crypto/acme/autocert"
+)
+
+// recordingCache is a minimal in-memory autocert.Cache for gate tests.
+type recordingCache struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func newRecordingCache() *recordingCache {
+	return &recordingCache{m: make(map[string][]byte)}
+}
+
+func (c *recordingCache) Get(_ context.Context, name string) ([]byte, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if d, ok := c.m[name]; ok {
+		return d, nil
+	}
+	return nil, autocert.ErrCacheMiss
+}
+
+func (c *recordingCache) Put(_ context.Context, name string, data []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.m[name] = data
+	return nil
+}
+
+func (c *recordingCache) Delete(_ context.Context, name string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.m, name)
+	return nil
+}
+
+func (c *recordingCache) has(name string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, ok := c.m[name]
+	return ok
+}
+
+func TestClusterAwareCache_NonLeaderCertWriteAbsorbed(t *testing.T) {
+	under := newRecordingCache()
+	cc := NewClusterAwareCache(under, func() bool { return false }, discardLogger())
+	ctx := context.Background()
+
+	// Absorbed: nil error (so autocert's renewal loop completes instead of
+	// re-issuing every 30-60min), but nothing persisted.
+	if err := cc.Put(ctx, "example.com", []byte("cert")); err != nil {
+		t.Errorf("non-leader cert Put must be absorbed with nil error, got %v", err)
+	}
+	if under.has("example.com") {
+		t.Error("non-leader cert write must NOT reach the shared store")
+	}
+}
+
+func TestClusterAwareCache_LeaderCertWritePersisted(t *testing.T) {
+	under := newRecordingCache()
+	cc := NewClusterAwareCache(under, func() bool { return true }, discardLogger())
+	ctx := context.Background()
+
+	if err := cc.Put(ctx, "example.com", []byte("cert")); err != nil {
+		t.Fatalf("leader Put: %v", err)
+	}
+	if !under.has("example.com") {
+		t.Error("leader cert write must be persisted")
+	}
+}
+
+func TestClusterAwareCache_TokensAndAccountKeyPassThrough(t *testing.T) {
+	under := newRecordingCache()
+	cc := NewClusterAwareCache(under, func() bool { return false }, discardLogger())
+	ctx := context.Background()
+
+	// Challenge tokens: any node running a validation must be able to
+	// publish and clean up its token.
+	for _, key := range []string{"example.com+token", "sometoken+http-01"} {
+		if err := cc.Put(ctx, key, []byte("tok")); err != nil {
+			t.Errorf("non-leader token Put(%q) must pass through: %v", key, err)
+		}
+		if !under.has(key) {
+			t.Errorf("token %q must reach the shared store", key)
+		}
+		if err := cc.Delete(ctx, key); err != nil {
+			t.Errorf("non-leader token Delete(%q) must pass through: %v", key, err)
+		}
+		if under.has(key) {
+			t.Errorf("token %q must be deletable by a non-leader", key)
+		}
+	}
+
+	// ACME account key (current and legacy names): blocking it errors out
+	// issuance entirely, and escape-hatch issuance must reuse the shared
+	// account rather than registering a new one per issuance.
+	for _, key := range []string{"acme_account+key", "acme_account.key"} {
+		if err := cc.Put(ctx, key, []byte("key")); err != nil {
+			t.Errorf("non-leader account-key Put(%q) must pass through: %v", key, err)
+		}
+		if !under.has(key) {
+			t.Errorf("account key %q must reach the shared store", key)
+		}
+	}
+}
+
+func TestClusterAwareCache_NonLeaderCertDeleteAbsorbed(t *testing.T) {
+	under := newRecordingCache()
+	under.m["example.com"] = []byte("cert")
+	cc := NewClusterAwareCache(under, func() bool { return false }, discardLogger())
+
+	if err := cc.Delete(context.Background(), "example.com"); err != nil {
+		t.Errorf("non-leader cert Delete must be absorbed with nil error, got %v", err)
+	}
+	if !under.has("example.com") {
+		t.Error("non-leader cert Delete must not remove the shared cert")
+	}
+}
+
+func TestClusterAwareCache_GetPassesThroughForAllNodes(t *testing.T) {
+	under := newRecordingCache()
+	under.m["example.com"] = []byte("cert")
+	cc := NewClusterAwareCache(under, func() bool { return false }, discardLogger())
+
+	got, err := cc.Get(context.Background(), "example.com")
+	if err != nil || !bytes.Equal(got, []byte("cert")) {
+		t.Errorf("non-leader Get must pass through, got %q err=%v", got, err)
+	}
+}

--- a/tlsmanager/storage/fallback_cache.go
+++ b/tlsmanager/storage/fallback_cache.go
@@ -263,19 +263,14 @@ func (f *FallbackCache) Get(ctx context.Context, key string) ([]byte, error) {
 		f.logger.Info("FallbackCache: certificate found in S3 - syncing to local cache", "name", key)
 		f.markS3Available()
 
-		// Store in local cache for future fast access (async to avoid blocking)
-		go func() {
-			defer func() {
-				if r := recover(); r != nil {
-					f.logger.Error("panic syncing to local cache", "panic", r)
-				}
-			}()
-			if putErr := f.fallback.Put(context.Background(), key, data); putErr != nil {
-				f.logger.Warn("FallbackCache: failed to sync certificate to local cache", "name", key, "error", putErr)
-			} else {
-				f.logger.Debug("FallbackCache: certificate synced to local cache", "name", key)
-			}
-		}()
+		// Store in local cache for future fast access. Synchronous on
+		// purpose: a local disk write is negligible next to the S3 fetch
+		// that just completed, and a detached goroutine could interleave
+		// with concurrent Deletes/Puts and resurrect bytes that were just
+		// superseded.
+		if putErr := f.fallback.Put(ctx, key, data); putErr != nil {
+			f.logger.Warn("FallbackCache: failed to sync certificate to local cache", "name", key, "error", putErr)
+		}
 
 		return data, nil
 	}


### PR DESCRIPTION
Stage 2 of the clustered-TLS re-architecture, **stacked on #33**. Deploy only after #33 is fleet-wide; when deploying this stage, restart the current cluster leader (lexicographically smallest `node_id`) first so the warmer is live before followers go read-only.

## Problem

With #33 alone, followers still run the full autocert path on cold handshakes: complete Let's Encrypt issuances that the `Put` gate then discards — wasted rate limit, and (worse) an error-returning gate turns a demoted ex-leader's renewal timers into a 30–60min duplicate-issuance loop, because autocert treats a failed `Cache.Put` on the *renewal* path as a failed renewal.

## Changes

**Handshake-layer gate** (`manager.go`, `follower.go`)
- **ALPN passthrough**: tls-alpn-01 validation probes (`acme-tls/1`) reach autocert on *every* node — autocert tries this challenge first, the CA's probe lands anywhere behind the LB, and serving it is a pure read of the challenge cert from the shared store (never an issuance).
- **Leaders / single-instance**: unchanged full autocert path.
- **Followers never initiate ACME.** They serve via a validating read path mirroring autocert's `cacheGet`/`validCert`: single PEM bundle (key first), validity window, hostname, key/cert match, trailing-garbage and damaged-chain rejection, and flavor selection through a faithful `supportsECDSA` mirror so a follower resolves the exact `domain` / `domain+rsa` key autocert would for the same hello. 60s in-memory memo; unservable local bytes (e.g. expired copy pinned by revalidation throttling) trigger a direct S3 refresh.
- **Escape hatch**: a hard miss sustained 5 minutes (leader gossip-alive but demonstrably not publishing) falls back to local issuance rather than an indefinite cluster-wide outage. Three guards from adversarial review:
  1. **No sawtooth**: a memoized cert past its TTL but still time-valid keeps being served (lease renewed, store re-probed each TTL) — otherwise a broken-leader outage decays to 60s-up/5min-down, since the absorbed write below keeps the escape cert out of the store.
  2. **Attempt cooldown**: one issuance attempt per flavor per 15 min, success or fail — a failing issuer retried per-handshake would burn ~60 ACME attempts/hour against LE's 5-failed-validations/hour budget.
  3. **Flavor gate**: never fires for `+rsa` when `warm_rsa_certs` is off — that key is legitimately absent and any client can fabricate an RSA-only hello, which would otherwise let unauthenticated handshakes drive ACME issuance on every follower.

**`ClusterAwareCache` becomes defense-in-depth with fixed semantics**
- Non-leader cert writes are **absorbed** (logged, dropped, `nil`) instead of rejected — ends the demoted-ex-leader loop at one discarded issuance; the node adopts the leader's cert at its next renewal check.
- Challenge tokens and the ACME account key (current + legacy names) pass through from any node: tokens must be publishable by whichever node runs a validation, and a blocked account-key write hard-fails issuance.

**`FallbackCache.Get`** S3→local sync is now synchronous (the detached goroutine could interleave with concurrent writes and resurrect superseded bytes).

## Verification

- Tests: follower store/flavor/memo/refresh/expired-adoption paths; escape-hatch no-sawtooth, retry-cooldown and RSA-gate anti-regressions; bundle strictness vs autocert (trailing garbage, damaged chain); `supportsECDSA` mirror (bare hello = RSA trap); ALPN detection; absorb-vs-passthrough gate matrix. `go vet` clean, full suite + `-race` green.
- All claims about autocert behavior were verified against the pinned `x/crypto v0.53.0` source by a 47-agent adversarial review (19 confirmed findings, all addressed).

## Rollout

1. Merge + deploy #33 fleet-wide; watch for `follower` hard-miss errors going to ~zero (`TLS: failed to get certificate` at Error level).
2. Optionally validate issuance end-to-end against LE staging via `directory_url` (isolated store is automatic).
3. Deploy this stage, leader first. The absorb log line (`cluster cache: absorbing certificate write from non-leader`) firing more than once per leadership change is the signal to investigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)