### PR TITLE
proxy: fix 2FA cookie Secure flag, document reverse-proxy setup

### DIFF
--- a/cmd/alps/main.go
+++ b/cmd/alps/main.go
@@ -175,6 +175,12 @@ func main() {
 
 	if config.WebAuthn.RPID != "" {
 		rpID = config.WebAuthn.RPID
+	} else {
+		// WebAuthn is bound to the browser-facing hostname and cannot be derived
+		// from forwarded headers, so a proxied deployment that leaves this unset
+		// silently falls back to localhost and fails in the browser at enrolment.
+		logger.Warnf("WebAuthn: [webauthn] rpid is unset, defaulting to %q — 2FA will not work "+
+			"unless served from localhost; set rpid and origins to your public hostname", rpID)
 	}
 	if config.WebAuthn.RPDisplayName != "" {
 		rpDisplayName = config.WebAuthn.RPDisplayName

--- a/context.go
+++ b/context.go
@@ -151,15 +151,17 @@ func (c *Context) IsTLS() bool {
 	return c.Request.TLS != nil
 }
 
-// isEffectiveHTTPS reports whether the browser's connection is HTTPS, accounting
+// IsEffectiveHTTPS reports whether the browser's connection is HTTPS, accounting
 // for a trusted TLS-terminating reverse proxy that forwards plain HTTP with
 // X-Forwarded-Proto. Cookie Secure flags must reflect the browser-facing scheme,
 // not the (possibly plaintext) hop between the proxy and alps — otherwise the
-// session cookie and the login-token cookie (which carries the fernet-encrypted
-// password) would be set without Secure in the recommended proxy deployment.
-// Forwarded headers are only honored when the immediate peer is a configured
-// trusted proxy, mirroring the CSRF middleware.
-func (c *Context) isEffectiveHTTPS() bool {
+// session cookie, the login-token cookie (which carries the fernet-encrypted
+// password) and the 2FA cookies would be set without Secure in the recommended
+// proxy deployment. Forwarded headers are only honored when the immediate peer is
+// a configured trusted proxy, mirroring the CSRF middleware.
+//
+// Always prefer this over IsTLS when deciding a cookie's Secure flag.
+func (c *Context) IsEffectiveHTTPS() bool {
 	if c.IsTLS() {
 		return true
 	}
@@ -190,14 +192,14 @@ func (c *Context) SetSessionWithExpiry(s *Session, persistent bool) {
 		Path:     "/", // Important: cookie must be valid for all paths
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,
-		Secure:   c.isEffectiveHTTPS(),
+		Secure:   c.IsEffectiveHTTPS(),
 	}
 	frontendCookie := http.Cookie{
 		Name:     "alps_logged_in",
 		Path:     "/",
 		HttpOnly: false,
 		SameSite: http.SameSiteStrictMode,
-		Secure:   c.isEffectiveHTTPS(),
+		Secure:   c.IsEffectiveHTTPS(),
 	}
 
 	if s != nil {
@@ -231,7 +233,7 @@ func (c *Context) SetLoginToken(username, password string, verified2FA bool, per
 		Name:     loginTokenCookieName,
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,
-		Secure:   c.isEffectiveHTTPS(),
+		Secure:   c.IsEffectiveHTTPS(),
 		Path:     "/",
 	}
 	frontendCookie := http.Cookie{
@@ -239,7 +241,7 @@ func (c *Context) SetLoginToken(username, password string, verified2FA bool, per
 		Path:     "/",
 		HttpOnly: false,
 		SameSite: http.SameSiteStrictMode,
-		Secure:   c.isEffectiveHTTPS(),
+		Secure:   c.IsEffectiveHTTPS(),
 	}
 
 	if persistent {

--- a/context_test.go
+++ b/context_test.go
@@ -3,10 +3,14 @@ package alps
 import (
 	"crypto/tls"
 	"encoding/json"
+	"io/fs"
 	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -48,7 +52,7 @@ func TestContext_CookieSecureReflectsForwardedProto(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.wantSecure, tc.ctx.isEffectiveHTTPS())
+			assert.Equal(t, tc.wantSecure, tc.ctx.IsEffectiveHTTPS())
 		})
 	}
 
@@ -60,6 +64,38 @@ func TestContext_CookieSecureReflectsForwardedProto(t *testing.T) {
 			assert.True(t, ck.Secure, "session cookie must be Secure behind an https-terminating trusted proxy")
 		}
 	}
+}
+
+// TestCookieSecureUsesEffectiveHTTPS guards every cookie in the tree, including
+// the ones set from the plugin packages (the 2FA cookies used to get this wrong).
+// IsTLS only describes the proxy-to-alps hop, so a cookie whose Secure flag is
+// derived from it silently loses Secure behind a TLS-terminating reverse proxy.
+func TestCookieSecureUsesEffectiveHTTPS(t *testing.T) {
+	badSecure := regexp.MustCompile(`Secure:\s*\w+\.IsTLS\(\)`)
+
+	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "node_modules", "dist", "frontend", "build", ".git":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		assert.NotRegexp(t, badSecure, string(src),
+			"%s: derive a cookie's Secure flag from Context.IsEffectiveHTTPS, not IsTLS", path)
+		return nil
+	})
+	assert.NoError(t, err)
 }
 
 func TestContextSetGet(t *testing.T) {

--- a/context_test.go
+++ b/context_test.go
@@ -78,8 +78,11 @@ func TestCookieSecureUsesEffectiveHTTPS(t *testing.T) {
 			return err
 		}
 		if d.IsDir() {
+			// Skip everything that isn't first-party source: build output, the
+			// frontend, vendored deps, and scratch dirs that may hold stale .go
+			// files (air builds into tmp/).
 			switch d.Name() {
-			case "node_modules", "dist", "frontend", "build", ".git":
+			case "node_modules", "dist", "frontend", "build", ".git", "tmp", "cert-cache", "vendor":
 				return fs.SkipDir
 			}
 			return nil

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -11,7 +11,8 @@ This section contains core settings for the ALPS HTTP server, session management
 | :--- | :--- | :--- | :--- |
 | `addr` | String | `":1323"` | The address and port on which the server listens. |
 | `debug` | Boolean | `true` | Enables debug mode. When `true`, logging level defaults to "debug" and console formatting is used. |
-| `trusted_proxies`| Array | `[]` | Array of IPs/CIDR blocks to trust `X-Forwarded-For` and `X-Real-IP` headers from (e.g. `["127.0.0.1/32"]`). Must be set if behind a proxy. |
+| `trusted_proxies`| Array | `[]` | Array of IPs/CIDR blocks to trust `X-Forwarded-For`, `X-Real-IP`, `X-Forwarded-Proto` and `X-Forwarded-Host` headers from (e.g. `["127.0.0.1/32"]`). Must be set if behind a proxy — see [Running behind a reverse proxy](TLS.md#5-reverse-proxies). |
+| `trusted_origins`| Array | `[]` | (Optional) Additional origins accepted by the CSRF check, in addition to the one ALPS derives from the request (e.g. `["https://webmail.example.com"]`). Use when the proxy cannot set `X-Forwarded-Proto`/`X-Forwarded-Host`. |
 | `login_key` | String | None | (Optional) Fernet key for encrypting user credentials in browser cookies. Enables "remember me" functionality and session restoration across server restarts. Changing this key invalidates all persisted sessions. |
 | `temp_dir` | String | OS Default | (Optional) Directory for temporary file uploads and processing. |
 | `session_minutes` | Integer | `30` | Duration of user sessions in minutes without activity. |

--- a/docs/TLS.md
+++ b/docs/TLS.md
@@ -172,10 +172,10 @@ frontend https-in
     bind :443 ssl crt /etc/haproxy/certs/webmail.example.com.pem
     mode http
 
-    option forwardfor                                          # X-Forwarded-For
+    option forwardfor                                           # X-Forwarded-For
     http-request set-header X-Forwarded-Proto https             # required
-    http-request set-header X-Forwarded-Host %[req.hdr(host)]
-    http-request set-header X-Real-IP %[src]
+    http-request set-header X-Forwarded-Host  %[req.hdr(host)]
+    http-request set-header X-Real-IP         %[src]
 
     default_backend alps
 

--- a/docs/TLS.md
+++ b/docs/TLS.md
@@ -133,6 +133,113 @@ If you prefer to place ALPS behind a reverse proxy like Nginx, Caddy, or HAProxy
 enabled = false
 ```
 
+### Forwarding the Browser-Facing Scheme and Host
+
+When the proxy terminates TLS it speaks HTTPS to the browser but plain HTTP to ALPS. ALPS cannot see the browser's scheme from the connection alone, so **you must forward it** — otherwise ALPS derives `http://your.host` as the expected origin while the browser sends `Origin: https://your.host`, and every state-changing request (login, send, delete) is rejected:
+
+```
+CSRF: Origin mismatch: got "https://mail.example.org", expected "http://mail.example.org"
+Request error: code=403, message=Invalid origin
+```
+
+The same information also decides whether session and login cookies get the `Secure` flag, so forwarding it is a security requirement, not just a convenience.
+
+**Recommended — forward the headers and declare the proxy as trusted:**
+
+**Nginx:**
+```nginx
+server {
+    listen 443 ssl;
+    server_name webmail.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/webmail.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/webmail.example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:1323;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Forwarded-Proto $scheme;   # required: https
+        proxy_set_header X-Forwarded-Host  $http_host;   # $host drops the port
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP         $remote_addr;
+    }
+}
+```
+
+**HAProxy:**
+```haproxy
+frontend https-in
+    bind :443 ssl crt /etc/haproxy/certs/webmail.example.com.pem
+    mode http
+
+    option forwardfor                                          # X-Forwarded-For
+    http-request set-header X-Forwarded-Proto https             # required
+    http-request set-header X-Forwarded-Host %[req.hdr(host)]
+    http-request set-header X-Real-IP %[src]
+
+    default_backend alps
+
+backend alps
+    mode http
+    server alps1 127.0.0.1:1323 check
+```
+
+Use `set-header`, not `add-header`: `set-header` drops any copy the client sent before writing its own. With `add-header` a client could prepend `X-Forwarded-Proto: http` and ALPS — which reads the first value of the list — would take the client's value over the proxy's. If the frontend also serves plain HTTP, derive the scheme instead of hardcoding it: `http-request set-header X-Forwarded-Proto %[ssl_fc,iif(https,http)]`.
+
+**Caddy:**
+```caddyfile
+webmail.example.com {
+    reverse_proxy 127.0.0.1:1323
+}
+```
+
+No header directives are needed — `reverse_proxy` sets `X-Forwarded-Proto`, `X-Forwarded-Host` and `X-Forwarded-For` on its own, passes the original `Host` through, and Caddy obtains the certificate automatically. You still have to list the proxy in `trusted_proxies` below, or ALPS will ignore the headers Caddy sends.
+
+Whichever proxy you use, declare it as trusted in `config.toml`:
+
+```toml
+[server]
+addr = "127.0.0.1:1323"
+# Only IPs listed here may set the X-Forwarded-* headers above. Anyone able to
+# reach ALPS directly could otherwise spoof them, so keep this list tight.
+trusted_proxies = ["127.0.0.1/32", "::1/128"]
+```
+
+ALPS honors `X-Forwarded-Proto` and `X-Forwarded-Host` **only** when the immediate peer matches `trusted_proxies`. Setting the headers without `trusted_proxies` (or the reverse) has no effect.
+
+If the proxy listens on a non-default port, `X-Forwarded-Host` must carry it (`webmail.example.com:8443`) — the browser includes the port in `Origin`, so a port-stripped value will not match. This is why the Nginx example uses `$http_host` rather than `$host`; HAProxy's `req.hdr(host)` and Caddy already preserve it.
+
+When a request is rejected, the log line names the likely cause, e.g.:
+
+```
+CSRF: Origin mismatch: got "https://mail.example.org", expected "http://mail.example.org"
+  (scheme differs and the peer 127.0.0.1 is not in trusted_proxies; behind a TLS-terminating
+   proxy, forward X-Forwarded-Proto and list the proxy in trusted_proxies, or set trusted_origins)
+```
+
+**Alternative — pin the origin explicitly:**
+
+If your proxy cannot set the forwarded headers, allowlist the browser-facing origin instead:
+
+```toml
+[server]
+trusted_origins = ["https://webmail.example.com"]
+```
+
+The browser's `Origin` must match an entry exactly (scheme + host + port). Note that this covers only the CSRF check; without `X-Forwarded-Proto` from a trusted proxy, cookies are still issued without `Secure`, so prefer the forwarded-header setup where possible.
+
+Do **not** work around the mismatch by rewriting the `Origin` header in the proxy (`proxy_set_header Origin http://$host;`). That makes every request look same-origin to ALPS, including genuine cross-site ones, which defeats the CSRF check.
+
+### WebAuthn Behind a Proxy
+
+WebAuthn (2FA / passkeys) is bound to the browser-facing hostname and is **not** derived from forwarded headers. The defaults target local development (`localhost`), so a proxied deployment must set them explicitly or registration and verification will fail:
+
+```toml
+[webauthn]
+rpid = "webmail.example.com"
+origins = ["https://webmail.example.com"]
+```
+
 ### Passing ACME Challenges through a Proxy
 
 If you still want ALPS to manage its own Let's Encrypt certificates but it sits behind a proxy, you must route the ACME HTTP-01 challenges to ALPS's `acme_http_addr` (e.g., `:8080`).

--- a/middleware.go
+++ b/middleware.go
@@ -1,8 +1,10 @@
 package alps
 
 import (
+	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -97,24 +99,37 @@ func originMatches(origin, expected string) bool {
 
 // csrfMismatchHint returns a short, actionable suffix for the rejection log when
 // the mismatch looks like a reverse-proxy misconfiguration rather than an actual
-// cross-site request. Both shapes below are configuration errors an operator can
-// fix, and the bare "got X, expected Y" line does not say how.
+// cross-site request. Each shape below is a configuration error an operator can
+// fix, and the bare "got X, expected Y" line does not say how. The hint goes to
+// the log only, never into the HTTP response.
 func csrfMismatchHint(ctx *Context, got, expectedOrigin string) string {
-	// The browser is on HTTPS but alps derived HTTP for the same host: a
-	// TLS-terminating proxy that is not forwarding (or is not trusted for)
-	// X-Forwarded-Proto.
-	gotHost := strings.TrimPrefix(strings.ToLower(got), "https://")
-	expectedHost := strings.TrimPrefix(strings.ToLower(expectedOrigin), "http://")
-	if strings.HasPrefix(strings.ToLower(got), "https://") &&
-		strings.HasPrefix(strings.ToLower(expectedOrigin), "http://") &&
-		(gotHost == expectedHost || strings.HasPrefix(gotHost, expectedHost+"/")) {
-		if !isRequestFromTrustedProxy(ctx) {
-			return " (scheme differs and the peer " + peerIP(ctx) + " is not in trusted_proxies;" +
-				" behind a TLS-terminating proxy, forward X-Forwarded-Proto and list the proxy in" +
-				" trusted_proxies, or set trusted_origins)"
+	gotURL, errGot := url.Parse(strings.ToLower(got))
+	expURL, errExp := url.Parse(strings.ToLower(expectedOrigin))
+	if errGot == nil && errExp == nil && gotURL.Host != "" && expURL.Host != "" {
+		// The browser is on HTTPS but alps derived HTTP for the same host: a
+		// TLS-terminating proxy that is not forwarding (or is not trusted for)
+		// X-Forwarded-Proto.
+		if gotURL.Scheme == "https" && expURL.Scheme == "http" && gotURL.Host == expURL.Host {
+			if !isRequestFromTrustedProxy(ctx) {
+				return " (scheme differs and the peer " + peerIP(ctx) + " is not in trusted_proxies;" +
+					" behind a TLS-terminating proxy, forward X-Forwarded-Proto and list the proxy in" +
+					" trusted_proxies, or set trusted_origins)"
+			}
+			if xfp := firstForwardedValue(ctx.Request.Header.Get("X-Forwarded-Proto")); xfp != "" {
+				return fmt.Sprintf(" (scheme differs; the trusted proxy forwards X-Forwarded-Proto %q"+
+					" instead of \"https\": fix it, or set trusted_origins)", xfp)
+			}
+			return " (scheme differs; the trusted proxy is not sending X-Forwarded-Proto:" +
+				" set it, or set trusted_origins)"
 		}
-		return " (scheme differs; the trusted proxy is not sending X-Forwarded-Proto:" +
-			" set it, or set trusted_origins)"
+
+		// Same scheme and hostname but a different (or missing) port: a proxy that
+		// strips the port when forwarding the host (e.g. nginx's $host).
+		if gotURL.Scheme == expURL.Scheme && gotURL.Hostname() == expURL.Hostname() &&
+			gotURL.Port() != expURL.Port() {
+			return " (hosts differ only by port; forward the browser-facing host with its port" +
+				" — e.g. nginx $http_host, not $host — or set trusted_origins)"
+		}
 	}
 
 	// Forwarded headers arrived but were ignored because the peer is untrusted —

--- a/middleware.go
+++ b/middleware.go
@@ -62,7 +62,7 @@ func CSRFMiddleware(next HandlerFunc) HandlerFunc {
 					ctx.Server.Logger().Printf("CSRF: Allowing localhost origin mismatch in development: got %q, expected %q", origin, expectedOrigin)
 					return next(ctx)
 				}
-				ctx.Server.Logger().Printf("CSRF: Origin mismatch: got %q, expected %q", origin, expectedOrigin)
+				ctx.Server.Logger().Printf("CSRF: Origin mismatch: got %q, expected %q%s", origin, expectedOrigin, csrfMismatchHint(ctx, origin, expectedOrigin))
 				return NewHTTPError(http.StatusForbidden, "Invalid origin")
 			}
 			return next(ctx)
@@ -72,7 +72,7 @@ func CSRFMiddleware(next HandlerFunc) HandlerFunc {
 		referer := ctx.Request.Header.Get("Referer")
 		if referer != "" {
 			if !refererMatches(referer, expectedOrigin) && !refererInList(referer, trustedOrigins) {
-				ctx.Server.Logger().Printf("CSRF: Referer mismatch: got %q, expected %q", referer, expectedOrigin)
+				ctx.Server.Logger().Printf("CSRF: Referer mismatch: got %q, expected %q%s", referer, expectedOrigin, csrfMismatchHint(ctx, referer, expectedOrigin))
 				return NewHTTPError(http.StatusForbidden, "Invalid referer")
 			}
 			return next(ctx)
@@ -93,6 +93,47 @@ func CSRFMiddleware(next HandlerFunc) HandlerFunc {
 // originMatches checks if the origin header matches the expected origin.
 func originMatches(origin, expected string) bool {
 	return strings.EqualFold(origin, expected)
+}
+
+// csrfMismatchHint returns a short, actionable suffix for the rejection log when
+// the mismatch looks like a reverse-proxy misconfiguration rather than an actual
+// cross-site request. Both shapes below are configuration errors an operator can
+// fix, and the bare "got X, expected Y" line does not say how.
+func csrfMismatchHint(ctx *Context, got, expectedOrigin string) string {
+	// The browser is on HTTPS but alps derived HTTP for the same host: a
+	// TLS-terminating proxy that is not forwarding (or is not trusted for)
+	// X-Forwarded-Proto.
+	gotHost := strings.TrimPrefix(strings.ToLower(got), "https://")
+	expectedHost := strings.TrimPrefix(strings.ToLower(expectedOrigin), "http://")
+	if strings.HasPrefix(strings.ToLower(got), "https://") &&
+		strings.HasPrefix(strings.ToLower(expectedOrigin), "http://") &&
+		(gotHost == expectedHost || strings.HasPrefix(gotHost, expectedHost+"/")) {
+		if !isRequestFromTrustedProxy(ctx) {
+			return " (scheme differs and the peer " + peerIP(ctx) + " is not in trusted_proxies;" +
+				" behind a TLS-terminating proxy, forward X-Forwarded-Proto and list the proxy in" +
+				" trusted_proxies, or set trusted_origins)"
+		}
+		return " (scheme differs; the trusted proxy is not sending X-Forwarded-Proto:" +
+			" set it, or set trusted_origins)"
+	}
+
+	// Forwarded headers arrived but were ignored because the peer is untrusted —
+	// the usual cause is a trusted_proxies list that omits the proxy's real address.
+	if !isRequestFromTrustedProxy(ctx) &&
+		(ctx.Request.Header.Get("X-Forwarded-Proto") != "" || ctx.Request.Header.Get("X-Forwarded-Host") != "") {
+		return " (X-Forwarded-* headers ignored: peer " + peerIP(ctx) + " is not in trusted_proxies)"
+	}
+
+	return ""
+}
+
+// peerIP returns the immediate peer's IP for diagnostics, falling back to the
+// raw RemoteAddr when it is not in host:port form.
+func peerIP(ctx *Context) string {
+	if host, _, err := net.SplitHostPort(ctx.Request.RemoteAddr); err == nil {
+		return host
+	}
+	return ctx.Request.RemoteAddr
 }
 
 // isLocalhostOrigin checks if an origin is localhost (for development).

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -360,7 +360,24 @@ func TestCSRFMismatchHint(t *testing.T) {
 	t.Run("scheme-only mismatch from trusted peer points at X-Forwarded-Proto", func(t *testing.T) {
 		ctx := newCtx("10.0.0.5:5000", private, nil)
 		hint := csrfMismatchHint(ctx, "https://example.com", "http://example.com")
-		assert.Contains(t, hint, "X-Forwarded-Proto")
+		assert.Contains(t, hint, "not sending X-Forwarded-Proto")
+	})
+
+	t.Run("trusted peer forwarding a wrong proto value is named", func(t *testing.T) {
+		ctx := newCtx("10.0.0.5:5000", private, map[string]string{"X-Forwarded-Proto": "http"})
+		hint := csrfMismatchHint(ctx, "https://example.com", "http://example.com")
+		assert.Contains(t, hint, `forwards X-Forwarded-Proto "http"`)
+	})
+
+	t.Run("port-only mismatch points at port-stripping proxy", func(t *testing.T) {
+		ctx := newCtx("10.0.0.5:5000", private, nil)
+		hint := csrfMismatchHint(ctx, "https://example.com:8443", "https://example.com")
+		assert.Contains(t, hint, "differ only by port")
+	})
+
+	t.Run("different hostname on same scheme gets no port hint", func(t *testing.T) {
+		ctx := newCtx("203.0.113.7:5000", private, nil)
+		assert.Empty(t, csrfMismatchHint(ctx, "https://evil.com:8443", "https://example.com"))
 	})
 
 	t.Run("referer form is recognized as scheme-only", func(t *testing.T) {

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -329,6 +329,52 @@ func TestCSRFMiddlewareBehindProxy(t *testing.T) {
 	}
 }
 
+// TestCSRFMismatchHint checks the operator-facing diagnostic attached to a
+// rejection: a plain cross-site request must not get a misconfiguration hint,
+// while the two proxy misconfigurations must say what to change.
+func TestCSRFMismatchHint(t *testing.T) {
+	newCtx := func(remoteAddr string, trustedProxies []*net.IPNet, headers map[string]string) *Context {
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Host = "example.com"
+		req.RemoteAddr = remoteAddr
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+		server := &Server{logger: &NilLogger{}, Options: &Options{TrustedProxies: trustedProxies}}
+		return NewContext(httptest.NewRecorder(), req, server)
+	}
+	private := []*net.IPNet{mustCIDR("10.0.0.0/8")}
+
+	t.Run("genuine cross-site request gets no hint", func(t *testing.T) {
+		ctx := newCtx("203.0.113.7:5000", private, nil)
+		assert.Empty(t, csrfMismatchHint(ctx, "https://evil.com", "https://example.com"))
+	})
+
+	t.Run("scheme-only mismatch from untrusted peer points at trusted_proxies", func(t *testing.T) {
+		ctx := newCtx("203.0.113.7:5000", private, nil)
+		hint := csrfMismatchHint(ctx, "https://example.com", "http://example.com")
+		assert.Contains(t, hint, "trusted_proxies")
+		assert.Contains(t, hint, "203.0.113.7")
+	})
+
+	t.Run("scheme-only mismatch from trusted peer points at X-Forwarded-Proto", func(t *testing.T) {
+		ctx := newCtx("10.0.0.5:5000", private, nil)
+		hint := csrfMismatchHint(ctx, "https://example.com", "http://example.com")
+		assert.Contains(t, hint, "X-Forwarded-Proto")
+	})
+
+	t.Run("referer form is recognized as scheme-only", func(t *testing.T) {
+		ctx := newCtx("10.0.0.5:5000", private, nil)
+		assert.NotEmpty(t, csrfMismatchHint(ctx, "https://example.com/mailbox", "http://example.com"))
+	})
+
+	t.Run("forwarded headers from untrusted peer are called out", func(t *testing.T) {
+		ctx := newCtx("203.0.113.7:5000", private, map[string]string{"X-Forwarded-Proto": "https"})
+		hint := csrfMismatchHint(ctx, "https://other.example.com", "http://example.com")
+		assert.Contains(t, hint, "not in trusted_proxies")
+	})
+}
+
 func TestFirstForwardedValue(t *testing.T) {
 	assert.Equal(t, "https", firstForwardedValue("https"))
 	assert.Equal(t, "https", firstForwardedValue("https, http"))

--- a/plugins/base/routes.go
+++ b/plugins/base/routes.go
@@ -913,7 +913,7 @@ func handleLogin(ctx *alps.Context) error {
 				Path:     "/",
 				HttpOnly: true,
 				SameSite: http.SameSiteStrictMode,
-				Secure:   ctx.IsTLS(),
+				Secure:   ctx.IsEffectiveHTTPS(),
 				MaxAge:   300, // 5 minutes
 			})
 
@@ -925,7 +925,7 @@ func handleLogin(ctx *alps.Context) error {
 					Path:     "/",
 					HttpOnly: true,
 					SameSite: http.SameSiteStrictMode,
-					Secure:   ctx.IsTLS(),
+					Secure:   ctx.IsEffectiveHTTPS(),
 					MaxAge:   300, // 5 minutes
 				})
 			}
@@ -2456,7 +2456,7 @@ func handleSwitchAccount(ctx *alps.Context) error {
 			Path:     "/",
 			HttpOnly: true,
 			SameSite: http.SameSiteStrictMode,
-			Secure:   ctx.IsTLS(),
+			Secure:   ctx.IsEffectiveHTTPS(),
 			MaxAge:   300, // 5 minutes
 		})
 

--- a/plugins/base/webauthn.go
+++ b/plugins/base/webauthn.go
@@ -447,7 +447,7 @@ func handleVerifyFinish(ctx *alps.Context) error {
 		Path:     "/",
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,
-		Secure:   ctx.IsTLS(),
+		Secure:   ctx.IsEffectiveHTTPS(),
 		MaxAge:   -1,
 	})
 
@@ -463,7 +463,7 @@ func handleVerifyFinish(ctx *alps.Context) error {
 			Path:     "/",
 			HttpOnly: true,
 			SameSite: http.SameSiteStrictMode,
-			Secure:   ctx.IsTLS(),
+			Secure:   ctx.IsEffectiveHTTPS(),
 			MaxAge:   -1,
 		})
 	}

--- a/server.go
+++ b/server.go
@@ -497,7 +497,7 @@ func (s *Server) setupMiddleware(router *Router) {
 						Path:     "/",
 						HttpOnly: true,
 						SameSite: http.SameSiteStrictMode,
-						Secure:   ctx.IsTLS(),
+						Secure:   ctx.IsEffectiveHTTPS(),
 						MaxAge:   -1,
 					})
 					ctx.SetCookie(&http.Cookie{
@@ -506,7 +506,7 @@ func (s *Server) setupMiddleware(router *Router) {
 						Path:     "/",
 						HttpOnly: true,
 						SameSite: http.SameSiteStrictMode,
-						Secure:   ctx.IsTLS(),
+						Secure:   ctx.IsEffectiveHTTPS(),
 						MaxAge:   -1,
 					})
 					// Continue with restored session


### PR DESCRIPTION
Follows up on a user report: running behind a TLS-terminating nginx, alps rejected every state-changing request with

```
CSRF: Origin mismatch: got "https://mail.example.org", expected "http://mail.example.org"
Request error: code=403, message=Invalid origin
```

and the reported workaround was rewriting the `Origin` header in the proxy — which makes every request look same-origin to alps, including genuine cross-site ones, defeating the CSRF check entirely.

The mechanisms to handle this properly already landed in #12 (`X-Forwarded-Proto`/`-Host` honored from `trusted_proxies`, plus a `trusted_origins` allowlist). They were just undocumented outside `config.example.toml`, and the rejection log gave the operator nothing to act on. Their nginx forwarded `Host` but not `X-Forwarded-Proto`, so `trusted_proxies` was doing nothing.

## Bug found while auditing

Only the session and login-token cookies used the proxy-aware scheme. The 2FA cookies still derived `Secure` from `IsTLS()`, which only describes the proxy-to-alps hop — so `alps_2fa_pending` (carries a session token) and `alps_2fa_remember` were issued **without `Secure`** in exactly the deployment we recommend.

- Exported `Context.IsEffectiveHTTPS` (plugins couldn't reach the unexported form) and switched all seven remaining sites in `server.go`, `plugins/base/routes.go`, `plugins/base/webauthn.go`.
- `TestCookieSecureUsesEffectiveHTTPS` scans the tree for `Secure: ...IsTLS()`, so a new cookie site can't reintroduce this across package boundaries. Verified it fails when the pattern is reintroduced.

`middleware.go` keeps its own `IsTLS()` call: the CSRF path needs the host from `X-Forwarded-Host` alongside the scheme, so it resolves both itself rather than going through the boolean.

## Diagnostics

CSRF rejections now name the likely cause, distinguishing a scheme-only mismatch (proxy not forwarding, or not trusted) from `X-Forwarded-*` arriving from a peer outside `trusted_proxies`:

```
CSRF: Origin mismatch: got "https://mail.example.org", expected "http://mail.example.org"
  (scheme differs and the peer 127.0.0.1 is not in trusted_proxies; behind a TLS-terminating
   proxy, forward X-Forwarded-Proto and list the proxy in trusted_proxies, or set trusted_origins)
```

A genuine cross-site origin gets no hint, so the log doesn't teach an attacker anything or dilute real signal.

Also warns at startup when `[webauthn] rpid` is unset — it's bound to the browser-facing hostname, can't be derived from forwarded headers, and silently defaulting to `localhost` fails only later, in the browser at enrolment.

## Docs

`docs/TLS.md` §5 gains a full reverse-proxy section: Nginx, HAProxy and Caddy examples, the shared `trusted_proxies` config, the `trusted_origins` fallback (with the caveat that it fixes CSRF but not the cookie `Secure` flag), and an explicit warning against the `Origin`-rewrite workaround. `trusted_origins` is documented in `docs/CONFIGURATION.md` for the first time.

Two details worth flagging for review:
- **HAProxy** must use `set-header`, not `add-header` — `add-header` leaves a client-supplied `X-Forwarded-Proto` in front of the proxy's value, and alps reads the first comma-separated value.
- **`X-Forwarded-Host` must keep the port.** nginx's `$host` strips it, so the example uses `$http_host`; the browser includes non-default ports in `Origin`.

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt` clean
- `go test ./...` — full suite passes
- Regression guard verified in both directions (fails with the bad pattern present, passes once reverted)
