### PR TITLE
imap: skip STATUS on non-selectable folders to fix Gmail blank screen

### DIFF
--- a/plugins/base/routes.go
+++ b/plugins/base/routes.go
@@ -385,10 +385,23 @@ func getBaseMailboxData(ctx *alps.Context) (*BaseMailboxData, error) {
 							ctx.Server.Logger().Debugf("Cache MISS for status:%s (via LIST-STATUS)", mbox.Name())
 						}
 					} else if statusesToFetch[mbox.Name()] || mbox.Subscribed {
+						// Non-selectable folders (e.g. Gmail's "[Gmail]"
+						// container) never get a status via LIST-STATUS and
+						// reject an explicit STATUS with NO [NONEXISTENT].
+						if mbox.HasAttr(string(imap.MailboxAttrNoSelect)) ||
+							mbox.HasAttr(string(imap.MailboxAttrNonExistent)) {
+							continue
+						}
 						// Server doesn't support LIST-STATUS, need individual STATUS command
 						status, err := getMailboxStatusWithProvider(p, mbox.Name())
 						if err != nil {
-							return err
+							if statusesToFetch[mbox.Name()] {
+								return err
+							}
+							// A sidebar folder's STATUS failure must not take
+							// down the whole mailbox view.
+							ctx.Server.Logger().Errorf("Failed to get status for mailbox %q: %v", mbox.Name(), err)
+							continue
 						}
 						statuses[mbox.Name()] = status
 						ctx.Session.Cache().Set("status:"+mbox.Name(), status)


### PR DESCRIPTION
Fixes #35

## Problem

Logging into a Gmail account rendered a blank screen, with the log showing:

```
level=ERROR msg="Request error: failed to get mailbox status: imap: NO [NONEXISTENT] Invalid folder: [Gmail] (Failure)"
```

Gmail's IMAP exposes container folders like `[Gmail]` marked `\Noselect`. Per RFC 5819 the server returns no STATUS for them in LIST-STATUS, so they come back with `Total/Unseen = -1`. The fallback loop in `getBaseMailboxData` took `-1` to mean "server lacks LIST-STATUS" and issued an explicit `STATUS "[Gmail]"` — which Gmail rejects with `NO [NONEXISTENT]` — and the error aborted the entire mailbox view request.

This also explains the reporter's observation that starred/unread filtered views worked: those use the `mboxName == "*"` early path, which never issues per-folder STATUS.

## Fix

- Skip `\Noselect` / `\NonExistent` folders before the per-folder STATUS fallback — they can never be STATUSed.
- Tolerate STATUS failures on folders that were only being refreshed for the sidebar (log and continue) instead of failing the whole request. Folders explicitly needed for the current view (`statusesToFetch`) still propagate their error as before.

## Testing

- `go build ./...` and `go test ./plugins/base/ ./provider/...` pass.